### PR TITLE
jwt -> koajwt

### DIFF
--- a/test.js
+++ b/test.js
@@ -1,6 +1,5 @@
 var koa     = require('koa');
 var request = require('supertest');
-var jwt     = require('jsonwebtoken');
 var assert  = require('assert');
 
 var koajwt  = require('.');
@@ -53,7 +52,7 @@ describe('failure tests', function () {
 
   it('should throw if authorization header is not valid jwt', function(done) {
     var secret = 'shhhhhh';
-    var token = jwt.sign({foo: 'bar'}, secret);
+    var token = koajwt.sign({foo: 'bar'}, secret);
     
     var app = koa();
 
@@ -69,7 +68,7 @@ describe('failure tests', function () {
 
   it('should throw if audience is not expected', function(done) {
     var secret = 'shhhhhh';
-    var token = jwt.sign({foo: 'bar', aud: 'expected-audience'}, secret);
+    var token = koajwt.sign({foo: 'bar', aud: 'expected-audience'}, secret);
     
     var app = koa();
 
@@ -84,7 +83,7 @@ describe('failure tests', function () {
 
   it('should throw if token is expired', function(done) {
     var secret = 'shhhhhh';
-    var token = jwt.sign({foo: 'bar', exp: 1382412921 }, secret);
+    var token = koajwt.sign({foo: 'bar', exp: 1382412921 }, secret);
     
     var app = koa();
 
@@ -99,7 +98,7 @@ describe('failure tests', function () {
 
   it('should throw if token issuer is wrong', function(done) {
     var secret = 'shhhhhh';
-    var token = jwt.sign({foo: 'bar', iss: 'http://foo' }, secret);
+    var token = koajwt.sign({foo: 'bar', iss: 'http://foo' }, secret);
     
     var app = koa();
 
@@ -141,7 +140,7 @@ describe('success tests', function () {
     }
 
     var secret = 'shhhhhh';
-    var token = jwt.sign({foo: 'bar'}, secret);
+    var token = koajwt.sign({foo: 'bar'}, secret);
     
     var app = koa();
 
@@ -165,7 +164,7 @@ describe('success tests', function () {
     }
 
     var secret = 'shhhhhh';
-    var token = jwt.sign({foo: 'bar'}, secret);
+    var token = koajwt.sign({foo: 'bar'}, secret);
     
     var app = koa();
 


### PR DESCRIPTION
No logic to require `jsonwebtoken` in tests again, when koa-jwt object have all methods implemented.
