### PR TITLE
Passthrough can be RegExp as well as boolean, Cookie auth falls back to Header, better error msg

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ even if no valid Authorization header was found:
 app.use(jwt({ secret: 'shared-secret', passthrough: true }));
 ```
 This lets downstream middleware make decisions based on whether `ctx.state.user` is set.
+Passing a RegExp to passthrough instead of true allows you to only enable passthrough for 
+paths that match the RegExp. For example, to enable passthrough only on /passthrough:
+
+```js
+app.use(jwt({ secret: 'shared-secret', passthrough: /^\/passthrough$/ }));
+```
 
 
 If you prefer to use another ctx key for the decoded data, just pass in `key`, like so:

--- a/index.js
+++ b/index.js
@@ -1,63 +1,77 @@
 var thunkify = require('thunkify');
 var _JWT     = require('jsonwebtoken');
 var unless   = require('koa-unless');
+var url      = require('url');
 
 // Make verify function play nice with co/koa
 var JWT = {decode: _JWT.decode, sign: _JWT.sign, verify: thunkify(_JWT.verify)};
 
 module.exports = function(opts) {
-  opts = opts || {};
-  opts.key = opts.key || 'user';
+    opts = opts || {};
+    opts.key = opts.key || 'user';
 
-  var middleware = function *jwt(next) {
-    var token, msg, user, parts, scheme, credentials, secret;
+    var middleware = function *jwt(next) {
+        var token, msg, user, parts, scheme, credentials, secret, passthrough;
 
-    if (opts.cookie && this.cookies.get(opts.cookie)) {
-      token = this.cookies.get(opts.cookie);
-
-    } else if (this.header.authorization) {
-      parts = this.header.authorization.split(' ');
-      if (parts.length == 2) {
-        scheme = parts[0];
-        credentials = parts[1];
-
-        if (/^Bearer$/i.test(scheme)) {
-          token = credentials;
+        if (opts.passthrough instanceof RegExp) {
+            passthrough = opts.passthrough.test(url.parse(this.url).pathname || '', true);
+        } else {
+            passthrough = opts.passthrough;
         }
-      } else {
-        if (!opts.passthrough) {
-          this.throw(401, 'Bad Authorization header format. Format is "Authorization: Bearer <token>"\n');
+
+        if (opts.cookie) {
+            token = this.cookies.get(opts.cookie);
+
+            if (!token && !passthrough && !this.header.authorization) {
+                this.throw(401, 'No Authorization cookie or header found\n');
+            }
         }
-      }
-    } else {
-      if (!opts.passthrough) {
-        this.throw(401, 'No Authorization header found\n');
-      }
-    }
 
-    secret = (this.state && this.state.secret) ? this.state.secret : opts.secret;
-    if (!secret) {
-      this.throw(401, 'Invalid secret\n');
-    }
+        if (!token) {
+            if (this.header.authorization) {
+                parts = this.header.authorization.split(' ');
+                if (parts.length == 2) {
+                    scheme = parts[0];
+                    credentials = parts[1];
 
-    try {
-      user = yield JWT.verify(token, secret, opts);
-    } catch(e) {
-      msg = 'Invalid token' + (opts.debug ? ' - ' + e.message + '\n' : '\n');
-    }
+                    if (/^Bearer$/i.test(scheme)) {
+                        token = credentials;
+                    }
+                } else {
+                    if (!passthrough) {
+                        this.throw(401, 'Bad Authorization header format. Format is "Authorization: Bearer <token>"\n');
+                    }
+                }
+            } else {
+                if (!passthrough) {
+                    this.throw(401, 'No Authorization header found\n');
+                }
+            }
+        }
 
-    if (user || opts.passthrough) {
-      this.state = this.state || {};
-      this.state[opts.key] = user;
-      yield next;
-    } else {
-      this.throw(401, msg);
-    }
-  };
+        secret = (this.state && this.state.secret) ? this.state.secret : opts.secret;
+        if (!secret) {
+            this.throw(401, 'Invalid secret\n');
+        }
 
-  middleware.unless = unless;
+        try {
+            user = yield JWT.verify(token, secret, opts);
+        } catch(e) {
+            msg = 'Invalid token' + (opts.debug ? ' - ' + e.message + '\n' : '\n');
+        }
 
-  return middleware;
+        if (user || passthrough) {
+            this.state = this.state || {};
+            this.state[opts.key] = user;
+            yield next;
+        } else {
+            this.throw(401, msg);
+        }
+    };
+
+    middleware.unless = unless;
+
+    return middleware;
 };
 
 // Export JWT methods as a convenience

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var thunkify = require('thunkify');
-var _JWT = require('jsonwebtoken');
-var unless = require('koa-unless');
-var url = require('url');
+var _JWT     = require('jsonwebtoken');
+var unless   = require('koa-unless');
+var url      = require('url');
 
 // Make verify function play nice with co/koa
 var JWT = {decode: _JWT.decode, sign: _JWT.sign, verify: thunkify(_JWT.verify)};
@@ -23,7 +23,7 @@ module.exports = function(opts) {
       token = this.cookies.get(opts.cookie);
 
       if (!token && !passthrough && !this.header.authorization) {
-        this.throw(401, 'No Authorization cookie or header found\n');
+        this.throw(401, 'Bad Authorization header format. Format is "Authorization: Bearer <token>"\n');
       }
     }
 
@@ -75,6 +75,6 @@ module.exports = function(opts) {
 };
 
 // Export JWT methods as a convenience
-module.exports.sign = _JWT.sign;
+module.exports.sign   = _JWT.sign;
 module.exports.verify = _JWT.verify;
 module.exports.decode = _JWT.decode;

--- a/index.js
+++ b/index.js
@@ -1,80 +1,80 @@
 var thunkify = require('thunkify');
-var _JWT     = require('jsonwebtoken');
-var unless   = require('koa-unless');
-var url      = require('url');
+var _JWT = require('jsonwebtoken');
+var unless = require('koa-unless');
+var url = require('url');
 
 // Make verify function play nice with co/koa
 var JWT = {decode: _JWT.decode, sign: _JWT.sign, verify: thunkify(_JWT.verify)};
 
 module.exports = function(opts) {
-    opts = opts || {};
-    opts.key = opts.key || 'user';
+  opts = opts || {};
+  opts.key = opts.key || 'user';
 
-    var middleware = function *jwt(next) {
-        var token, msg, user, parts, scheme, credentials, secret, passthrough;
+  var middleware = function *jwt(next) {
+    var token, msg, user, parts, scheme, credentials, secret, passthrough;
 
-        if (opts.passthrough instanceof RegExp) {
-            passthrough = opts.passthrough.test(url.parse(this.url).pathname || '', true);
+    if (opts.passthrough instanceof RegExp) {
+      passthrough = opts.passthrough.test(url.parse(this.url).pathname || '', true);
+    } else {
+      passthrough = opts.passthrough;
+    }
+
+    if (opts.cookie) {
+      token = this.cookies.get(opts.cookie);
+
+      if (!token && !passthrough && !this.header.authorization) {
+        this.throw(401, 'No Authorization cookie or header found\n');
+      }
+    }
+
+    if (!token) {
+      if (this.header.authorization) {
+        parts = this.header.authorization.split(' ');
+        if (parts.length == 2) {
+          scheme = parts[0];
+          credentials = parts[1];
+
+          if (/^Bearer$/i.test(scheme)) {
+            token = credentials;
+          }
         } else {
-            passthrough = opts.passthrough;
+          if (!passthrough) {
+            this.throw(401, 'Bad Authorization header format. Format is "Authorization: Bearer <token>"\n');
+          }
         }
-
-        if (opts.cookie) {
-            token = this.cookies.get(opts.cookie);
-
-            if (!token && !passthrough && !this.header.authorization) {
-                this.throw(401, 'No Authorization cookie or header found\n');
-            }
+      } else {
+        if (!passthrough) {
+          this.throw(401, 'No Authorization header found\n');
         }
+      }
+    }
 
-        if (!token) {
-            if (this.header.authorization) {
-                parts = this.header.authorization.split(' ');
-                if (parts.length == 2) {
-                    scheme = parts[0];
-                    credentials = parts[1];
+    secret = (this.state && this.state.secret) ? this.state.secret : opts.secret;
+    if (!secret) {
+      this.throw(401, 'Invalid secret\n');
+    }
 
-                    if (/^Bearer$/i.test(scheme)) {
-                        token = credentials;
-                    }
-                } else {
-                    if (!passthrough) {
-                        this.throw(401, 'Bad Authorization header format. Format is "Authorization: Bearer <token>"\n');
-                    }
-                }
-            } else {
-                if (!passthrough) {
-                    this.throw(401, 'No Authorization header found\n');
-                }
-            }
-        }
+    try {
+      user = yield JWT.verify(token, secret, opts);
+    } catch(e) {
+      msg = 'Invalid token' + (opts.debug ? ' - ' + e.message + '\n' : '\n');
+    }
 
-        secret = (this.state && this.state.secret) ? this.state.secret : opts.secret;
-        if (!secret) {
-            this.throw(401, 'Invalid secret\n');
-        }
+    if (user || passthrough) {
+      this.state = this.state || {};
+      this.state[opts.key] = user;
+      yield next;
+    } else {
+      this.throw(401, msg);
+    }
+  };
 
-        try {
-            user = yield JWT.verify(token, secret, opts);
-        } catch(e) {
-            msg = 'Invalid token' + (opts.debug ? ' - ' + e.message + '\n' : '\n');
-        }
+  middleware.unless = unless;
 
-        if (user || passthrough) {
-            this.state = this.state || {};
-            this.state[opts.key] = user;
-            yield next;
-        } else {
-            this.throw(401, msg);
-        }
-    };
-
-    middleware.unless = unless;
-
-    return middleware;
+  return middleware;
 };
 
 // Export JWT methods as a convenience
-module.exports.sign   = _JWT.sign;
+module.exports.sign = _JWT.sign;
 module.exports.verify = _JWT.verify;
 module.exports.decode = _JWT.decode;

--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-var assert   = require('assert');
 var thunkify = require('thunkify');
 var _JWT     = require('jsonwebtoken');
 var unless   = require('koa-unless');

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = function(opts) {
     var token, msg, user, parts, scheme, credentials, secret, passthrough;
 
     if (opts.passthrough instanceof RegExp) {
-      passthrough = opts.passthrough.test(url.parse(this.url).pathname || '', true);
+      passthrough = opts.passthrough.test(url.parse(this.url).pathname || '');
     } else {
       passthrough = opts.passthrough;
     }

--- a/test.js
+++ b/test.js
@@ -13,9 +13,9 @@ describe('failure tests', function () {
 
     app.use(koajwt({ secret: 'shhhh' }));
     request(app.listen())
-      .get('/')
-      .expect(401)
-      .end(done);
+    .get('/')
+    .expect(401)
+    .end(done);
   });
 
   it('should return 401 if authorization header is malformed', function(done) {
@@ -23,11 +23,11 @@ describe('failure tests', function () {
 
     app.use(koajwt({ secret: 'shhhh' }));
     request(app.listen())
-      .get('/')
-      .set('Authorization', 'wrong')
-      .expect(401)
-      .expect('Bad Authorization header format. Format is "Authorization: Bearer <token>"\n')
-      .end(done);
+    .get('/')
+    .set('Authorization', 'wrong')
+    .expect(401)
+    .expect('Bad Authorization header format. Format is "Authorization: Bearer <token>"\n')
+    .end(done);
   });
 
   it('should throw if authorization header is not well-formatted jwt', function(done) {
@@ -35,11 +35,11 @@ describe('failure tests', function () {
 
     app.use(koajwt({ secret: 'shhhh' }));
     request(app.listen())
-      .get('/')
-      .set('Authorization', 'Bearer wrongjwt')
-      .expect(401)
-      .expect('Invalid token\n')
-      .end(done);
+    .get('/')
+    .set('Authorization', 'Bearer wrongjwt')
+    .expect(401)
+    .expect('Invalid token\n')
+    .end(done);
   });
 
   it('should throw if authorization header is not valid jwt', function(done) {
@@ -50,12 +50,12 @@ describe('failure tests', function () {
 
     app.use(koajwt({ secret: 'different-shhhh', debug: true }));
     request(app.listen())
-      .get('/')
-      .set('Authorization', 'Bearer ' + token)
-      .expect(401)
-      .expect('Invalid token - invalid signature\n')
-      .end(done);
-      //   assert.equal(err.message, 'invalid signature');
+    .get('/')
+    .set('Authorization', 'Bearer ' + token)
+    .expect(401)
+    .expect('Invalid token - invalid signature\n')
+    .end(done);
+    //   assert.equal(err.message, 'invalid signature');
   });
 
   it('should throw if opts.cookies is set and the specified cookie is not well-formatted jwt', function(done) {
@@ -70,11 +70,11 @@ describe('failure tests', function () {
     });
 
     request(app.listen())
-      .get('/')
-      .set('Cookie', 'jwt=bad' + token + ';')
-      .expect(401)
-      .expect('Invalid token\n')
-      .end(done);
+    .get('/')
+    .set('Cookie', 'jwt=bad' + token + ';')
+    .expect(401)
+    .expect('Invalid token\n')
+    .end(done);
 
   });
 
@@ -86,11 +86,11 @@ describe('failure tests', function () {
 
     app.use(koajwt({ secret: 'shhhhhh', audience: 'not-expected-audience', debug: true }));
     request(app.listen())
-      .get('/')
-      .set('Authorization', 'Bearer ' + token)
-      .expect(401)
-      .expect('Invalid token - jwt audience invalid. expected: not-expected-audience\n')
-      .end(done);
+    .get('/')
+    .set('Authorization', 'Bearer ' + token)
+    .expect(401)
+    .expect('Invalid token - jwt audience invalid. expected: not-expected-audience\n')
+    .end(done);
   });
 
   it('should throw if token is expired', function(done) {
@@ -101,11 +101,11 @@ describe('failure tests', function () {
 
     app.use(koajwt({ secret: 'shhhhhh', debug: true }));
     request(app.listen())
-      .get('/')
-      .set('Authorization', 'Bearer ' + token)
-      .expect(401)
-      .expect('Invalid token - jwt expired\n')
-      .end(done);
+    .get('/')
+    .set('Authorization', 'Bearer ' + token)
+    .expect(401)
+    .expect('Invalid token - jwt expired\n')
+    .end(done);
   });
 
   it('should throw if token issuer is wrong', function(done) {
@@ -116,11 +116,11 @@ describe('failure tests', function () {
 
     app.use(koajwt({ secret: 'shhhhhh', issuer: 'http://wrong', debug: true }));
     request(app.listen())
-      .get('/')
-      .set('Authorization', 'Bearer ' + token)
-      .expect(401)
-      .expect('Invalid token - jwt issuer invalid. expected: http://wrong\n')
-      .end(done);
+    .get('/')
+    .set('Authorization', 'Bearer ' + token)
+    .expect(401)
+    .expect('Invalid token - jwt issuer invalid. expected: http://wrong\n')
+    .end(done);
   });
 
   it('should throw if secret neither provide by options and middleware', function (done) {
@@ -131,11 +131,11 @@ describe('failure tests', function () {
 
     app.use(koajwt({debug: true}));
     request(app.listen())
-      .get('/')
-      .set('Authorization', 'Bearer ' + token)
-      .expect(401)
-      .expect('Invalid secret\n')
-      .end(done);
+    .get('/')
+    .set('Authorization', 'Bearer ' + token)
+    .expect(401)
+    .expect('Invalid secret\n')
+    .end(done);
   });
 
   it('should throw if secret both provide by options(right secret) and middleware(wrong secret)', function (done) {
@@ -146,11 +146,11 @@ describe('failure tests', function () {
 
     app.use(koajwt({secret: 'wrong secret', debug: true}));
     request(app.listen())
-        .get('/')
-        .set('Authorization', 'Bearer ' + token)
-        .expect(401)
-        .expect('Invalid token - invalid signature\n')
-        .end(done);
+    .get('/')
+    .set('Authorization', 'Bearer ' + token)
+    .expect(401)
+    .expect('Invalid token - invalid signature\n')
+    .end(done);
   });
 
 });
@@ -165,10 +165,40 @@ describe('passthrough tests', function () {
     });
 
     request(app.listen())
-      .get('/')
-      .expect(204) // No content
-      .expect('')
-      .end(done);
+    .get('/')
+    .expect(204) // No content
+    .expect('')
+    .end(done);
+  });
+
+  it('should continue if `passthrough` is a RegExp and the path matches', function(done) {
+    var app = koa();
+
+    app.use(koajwt({ secret: 'shhhhhh', passthrough: /^\/passthrough/, debug: true }));
+    app.use(function* (next) {
+      this.body = this.state.user;
+    });
+
+    request(app.listen())
+    .get('/passthrough')
+    .expect(204) // No content
+    .expect('')
+    .end(done);
+  });
+
+  it('should not continue if `passthrough` is a RegExp and the path does not match', function(done) {
+    var app = koa();
+
+    app.use(koajwt({ secret: 'shhhhhh', passthrough: /^\/passthrough/, debug: true }));
+    app.use(function* (next) {
+      this.body = this.state.user;
+    });
+
+    request(app.listen())
+    .get('/dontpassthrough')
+    .expect(401)
+    .expect('No Authorization header found\n')
+    .end(done);
   });
 });
 
@@ -191,11 +221,11 @@ describe('success tests', function () {
     });
 
     request(app.listen())
-      .get('/')
-      .set('Authorization', 'Bearer ' + token)
-      .expect(200)
-      .expect(validUserResponse)
-      .end(done);
+    .get('/')
+    .set('Authorization', 'Bearer ' + token)
+    .expect(200)
+    .expect(validUserResponse)
+    .end(done);
 
   });
 
@@ -215,11 +245,35 @@ describe('success tests', function () {
     });
 
     request(app.listen())
-      .get('/')
-      .set('Cookie', 'jwt=' + token + ';')
-      .expect(200)
-      .expect(validUserResponse)
-      .end(done);
+    .get('/')
+    .set('Cookie', 'jwt=' + token + ';')
+    .expect(200)
+    .expect(validUserResponse)
+    .end(done);
+
+  });
+
+  it('should work if opts.cookies is set and there is no cookie but there is an authorization header with valid jwt', function(done) {
+    var validUserResponse = function(res) {
+      if (!(res.body.foo === 'bar')) return "Wrong user";
+    }
+
+    var secret = 'shhhhhh';
+    var token = koajwt.sign({foo: 'bar', cookie: 'jwt'}, secret);
+
+    var app = koa();
+
+    app.use(koajwt({ secret: secret }));
+    app.use(function* (next) {
+      this.body = this.state.user;
+    });
+
+    request(app.listen())
+    .get('/')
+    .set('Authorization', 'Bearer ' + token)
+    .expect(200)
+    .expect(validUserResponse)
+    .end(done);
 
   });
 
@@ -239,11 +293,11 @@ describe('success tests', function () {
     });
 
     request(app.listen())
-      .get('/')
-      .set('Authorization', 'Bearer ' + token)
-      .expect(200)
-      .expect(validUserResponse)
-      .end(done);
+    .get('/')
+    .set('Authorization', 'Bearer ' + token)
+    .expect(200)
+    .expect(validUserResponse)
+    .end(done);
 
   });
 
@@ -258,8 +312,8 @@ describe('success tests', function () {
     var app = koa();
 
     app.use(function *(next) {
-        this.state.secret = secret;
-        yield next;
+      this.state.secret = secret;
+      yield next;
     });
     app.use(koajwt());
     app.use(function* (next) {
@@ -267,11 +321,11 @@ describe('success tests', function () {
     });
 
     request(app.listen())
-        .get('/')
-        .set('Authorization', 'Bearer ' + token)
-        .expect(200)
-        .expect(validUserResponse)
-        .end(done);
+    .get('/')
+    .set('Authorization', 'Bearer ' + token)
+    .expect(200)
+    .expect(validUserResponse)
+    .end(done);
   });
 
 
@@ -295,11 +349,11 @@ describe('success tests', function () {
     });
 
     request(app.listen())
-        .get('/')
-        .set('Authorization', 'Bearer ' + token)
-        .expect(200)
-        .expect(validUserResponse)
-        .end(done);
+    .get('/')
+    .set('Authorization', 'Bearer ' + token)
+    .expect(200)
+    .expect(validUserResponse)
+    .end(done);
   });
 });
 
@@ -321,11 +375,11 @@ describe('unless tests', function () {
     });
 
     request(app.listen())
-      .get('/public')
-      .set('Authorization', 'wrong')
-      .expect(200)
-      .expect(validUserResponse)
-      .end(done);
+    .get('/public')
+    .set('Authorization', 'wrong')
+    .expect(200)
+    .expect(validUserResponse)
+    .end(done);
   });
 
   it('should fail if the route is not excluded', function(done) {
@@ -340,11 +394,11 @@ describe('unless tests', function () {
     });
 
     request(app.listen())
-      .get('/private')
-      .set('Authorization', 'wrong')
-      .expect(401)
-      .expect('Bad Authorization header format. Format is "Authorization: Bearer <token>"\n')
-      .end(done);
+    .get('/private')
+    .set('Authorization', 'wrong')
+    .expect(401)
+    .expect('Bad Authorization header format. Format is "Authorization: Bearer <token>"\n')
+    .end(done);
   });
 
   it('should pass if the route is not excluded and the token is present', function(done) {
@@ -363,12 +417,11 @@ describe('unless tests', function () {
     });
 
     request(app.listen())
-      .get('/')
-      .set('Authorization', 'Bearer ' + token)
-      .expect(200)
-      .expect(validUserResponse)
-      .end(done);
+    .get('/')
+    .set('Authorization', 'Bearer ' + token)
+    .expect(200)
+    .expect(validUserResponse)
+    .end(done);
 
   });
-  
 });

--- a/test.js
+++ b/test.js
@@ -1,17 +1,17 @@
 var TOKEN = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJmb28iOiJiYXIiLCJpYXQiOjE0MjY1NDY5MTl9.ETgkTn8BaxIX4YqvUWVFPmum3moNZ7oARZtSBXb_vP4';
 
-var koa     = require('koa');
+var koa = require('koa');
 var request = require('supertest');
-var assert  = require('assert');
+var assert = require('assert');
 
-var koajwt  = require('./index');
+var koajwt = require('./index');
 
-describe('failure tests', function () {
+describe('failure tests', function() {
 
   it('should throw 401 if no authorization header', function(done) {
     var app = koa();
 
-    app.use(koajwt({ secret: 'shhhh' }));
+    app.use(koajwt({secret: 'shhhh'}));
     request(app.listen())
     .get('/')
     .expect(401)
@@ -21,7 +21,7 @@ describe('failure tests', function () {
   it('should return 401 if authorization header is malformed', function(done) {
     var app = koa();
 
-    app.use(koajwt({ secret: 'shhhh' }));
+    app.use(koajwt({secret: 'shhhh'}));
     request(app.listen())
     .get('/')
     .set('Authorization', 'wrong')
@@ -33,7 +33,7 @@ describe('failure tests', function () {
   it('should throw if authorization header is not well-formatted jwt', function(done) {
     var app = koa();
 
-    app.use(koajwt({ secret: 'shhhh' }));
+    app.use(koajwt({secret: 'shhhh'}));
     request(app.listen())
     .get('/')
     .set('Authorization', 'Bearer wrongjwt')
@@ -48,7 +48,7 @@ describe('failure tests', function () {
 
     var app = koa();
 
-    app.use(koajwt({ secret: 'different-shhhh', debug: true }));
+    app.use(koajwt({secret: 'different-shhhh', debug: true}));
     request(app.listen())
     .get('/')
     .set('Authorization', 'Bearer ' + token)
@@ -64,7 +64,7 @@ describe('failure tests', function () {
 
     var app = koa();
 
-    app.use(koajwt({ secret: secret, cookie: 'jwt' }));
+    app.use(koajwt({secret: secret, cookie: 'jwt'}));
     app.use(function* (next) {
       this.body = this.state.user;
     });
@@ -84,7 +84,7 @@ describe('failure tests', function () {
 
     var app = koa();
 
-    app.use(koajwt({ secret: 'shhhhhh', audience: 'not-expected-audience', debug: true }));
+    app.use(koajwt({secret: 'shhhhhh', audience: 'not-expected-audience', debug: true}));
     request(app.listen())
     .get('/')
     .set('Authorization', 'Bearer ' + token)
@@ -95,11 +95,11 @@ describe('failure tests', function () {
 
   it('should throw if token is expired', function(done) {
     var secret = 'shhhhhh';
-    var token = koajwt.sign({foo: 'bar', exp: 1382412921 }, secret);
+    var token = koajwt.sign({foo: 'bar', exp: 1382412921}, secret);
 
     var app = koa();
 
-    app.use(koajwt({ secret: 'shhhhhh', debug: true }));
+    app.use(koajwt({secret: 'shhhhhh', debug: true}));
     request(app.listen())
     .get('/')
     .set('Authorization', 'Bearer ' + token)
@@ -110,11 +110,11 @@ describe('failure tests', function () {
 
   it('should throw if token issuer is wrong', function(done) {
     var secret = 'shhhhhh';
-    var token = koajwt.sign({foo: 'bar', iss: 'http://foo' }, secret);
+    var token = koajwt.sign({foo: 'bar', iss: 'http://foo'}, secret);
 
     var app = koa();
 
-    app.use(koajwt({ secret: 'shhhhhh', issuer: 'http://wrong', debug: true }));
+    app.use(koajwt({secret: 'shhhhhh', issuer: 'http://wrong', debug: true}));
     request(app.listen())
     .get('/')
     .set('Authorization', 'Bearer ' + token)
@@ -123,9 +123,9 @@ describe('failure tests', function () {
     .end(done);
   });
 
-  it('should throw if secret neither provide by options and middleware', function (done) {
+  it('should throw if secret neither provide by options and middleware', function(done) {
     var secret = 'shhhhhh';
-    var token = koajwt.sign({foo: 'bar', iss: 'http://foo' }, secret);
+    var token = koajwt.sign({foo: 'bar', iss: 'http://foo'}, secret);
 
     var app = koa();
 
@@ -138,9 +138,9 @@ describe('failure tests', function () {
     .end(done);
   });
 
-  it('should throw if secret both provide by options(right secret) and middleware(wrong secret)', function (done) {
+  it('should throw if secret both provide by options(right secret) and middleware(wrong secret)', function(done) {
     var secret = 'shhhhhh';
-    var token = koajwt.sign({foo: 'bar', iss: 'http://foo' }, secret);
+    var token = koajwt.sign({foo: 'bar', iss: 'http://foo'}, secret);
 
     var app = koa();
 
@@ -155,11 +155,11 @@ describe('failure tests', function () {
 
 });
 
-describe('passthrough tests', function () {
+describe('passthrough tests', function() {
   it('should continue if `passthrough` is true', function(done) {
     var app = koa();
 
-    app.use(koajwt({ secret: 'shhhhhh', passthrough: true, debug: true }));
+    app.use(koajwt({secret: 'shhhhhh', passthrough: true, debug: true}));
     app.use(function* (next) {
       this.body = this.state.user;
     });
@@ -174,7 +174,7 @@ describe('passthrough tests', function () {
   it('should continue if `passthrough` is a RegExp and the path matches', function(done) {
     var app = koa();
 
-    app.use(koajwt({ secret: 'shhhhhh', passthrough: /^\/passthrough/, debug: true }));
+    app.use(koajwt({secret: 'shhhhhh', passthrough: /^\/passthrough/, debug: true}));
     app.use(function* (next) {
       this.body = this.state.user;
     });
@@ -189,7 +189,7 @@ describe('passthrough tests', function () {
   it('should not continue if `passthrough` is a RegExp and the path does not match', function(done) {
     var app = koa();
 
-    app.use(koajwt({ secret: 'shhhhhh', passthrough: /^\/passthrough/, debug: true }));
+    app.use(koajwt({secret: 'shhhhhh', passthrough: /^\/passthrough/, debug: true}));
     app.use(function* (next) {
       this.body = this.state.user;
     });
@@ -202,8 +202,7 @@ describe('passthrough tests', function () {
   });
 });
 
-
-describe('success tests', function () {
+describe('success tests', function() {
 
   it('should work if authorization header is valid jwt', function(done) {
     var validUserResponse = function(res) {
@@ -215,7 +214,7 @@ describe('success tests', function () {
 
     var app = koa();
 
-    app.use(koajwt({ secret: secret }));
+    app.use(koajwt({secret: secret}));
     app.use(function* (next) {
       this.body = this.state.user;
     });
@@ -239,7 +238,7 @@ describe('success tests', function () {
 
     var app = koa();
 
-    app.use(koajwt({ secret: secret, cookie: 'jwt' }));
+    app.use(koajwt({secret: secret, cookie: 'jwt'}));
     app.use(function* (next) {
       this.body = this.state.user;
     });
@@ -263,7 +262,7 @@ describe('success tests', function () {
 
     var app = koa();
 
-    app.use(koajwt({ secret: secret }));
+    app.use(koajwt({secret: secret}));
     app.use(function* (next) {
       this.body = this.state.user;
     });
@@ -287,7 +286,7 @@ describe('success tests', function () {
 
     var app = koa();
 
-    app.use(koajwt({ secret: secret, key: 'jwtdata' }));
+    app.use(koajwt({secret: secret, key: 'jwtdata'}));
     app.use(function* (next) {
       this.body = this.state.jwtdata;
     });
@@ -301,7 +300,7 @@ describe('success tests', function () {
 
   });
 
-  it('should work if secret is provided by middleware', function (done) {
+  it('should work if secret is provided by middleware', function(done) {
     var validUserResponse = function(res) {
       if (!(res.body.foo === 'bar')) return "Wrong user";
     };
@@ -328,8 +327,7 @@ describe('success tests', function () {
     .end(done);
   });
 
-
-  it('should use middleware secret if both middleware and options provided', function (done) {
+  it('should use middleware secret if both middleware and options provided', function(done) {
     var validUserResponse = function(res) {
       if (!(res.body.foo === 'bar')) return "Wrong user";
     };
@@ -357,7 +355,7 @@ describe('success tests', function () {
   });
 });
 
-describe('unless tests', function () {
+describe('unless tests', function() {
 
   it('should pass if the route is excluded', function(done) {
     var validUserResponse = function(res) {
@@ -369,9 +367,9 @@ describe('unless tests', function () {
 
     var app = koa();
 
-    app.use(koajwt({ secret: secret }).unless({ path: ['/public']}));
+    app.use(koajwt({secret: secret}).unless({path: ['/public']}));
     app.use(function* (next) {
-      this.body = { success: true };
+      this.body = {success: true};
     });
 
     request(app.listen())
@@ -388,9 +386,9 @@ describe('unless tests', function () {
 
     var app = koa();
 
-    app.use(koajwt({ secret: secret }).unless({ path: ['/public']}));
+    app.use(koajwt({secret: secret}).unless({path: ['/public']}));
     app.use(function* (next) {
-      this.body = { success: true };
+      this.body = {success: true};
     });
 
     request(app.listen())
@@ -411,7 +409,7 @@ describe('unless tests', function () {
 
     var app = koa();
 
-    app.use(koajwt({ secret: secret, key: 'jwtdata' }).unless({ path: ['/public']}));
+    app.use(koajwt({secret: secret, key: 'jwtdata'}).unless({path: ['/public']}));
     app.use(function* (next) {
       this.body = this.state.jwtdata;
     });

--- a/test.js
+++ b/test.js
@@ -1,45 +1,45 @@
 var TOKEN = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJmb28iOiJiYXIiLCJpYXQiOjE0MjY1NDY5MTl9.ETgkTn8BaxIX4YqvUWVFPmum3moNZ7oARZtSBXb_vP4';
 
-var koa = require('koa');
+var koa     = require('koa');
 var request = require('supertest');
-var assert = require('assert');
+var assert  = require('assert');
 
-var koajwt = require('./index');
+var koajwt  = require('./index');
 
-describe('failure tests', function() {
+describe('failure tests', function () {
 
   it('should throw 401 if no authorization header', function(done) {
     var app = koa();
 
-    app.use(koajwt({secret: 'shhhh'}));
+    app.use(koajwt({ secret: 'shhhh' }));
     request(app.listen())
-    .get('/')
-    .expect(401)
-    .end(done);
+      .get('/')
+      .expect(401)
+      .end(done);
   });
 
   it('should return 401 if authorization header is malformed', function(done) {
     var app = koa();
 
-    app.use(koajwt({secret: 'shhhh'}));
+    app.use(koajwt({ secret: 'shhhh' }));
     request(app.listen())
-    .get('/')
-    .set('Authorization', 'wrong')
-    .expect(401)
-    .expect('Bad Authorization header format. Format is "Authorization: Bearer <token>"\n')
-    .end(done);
+      .get('/')
+      .set('Authorization', 'wrong')
+      .expect(401)
+      .expect('Bad Authorization header format. Format is "Authorization: Bearer <token>"\n')
+      .end(done);
   });
 
   it('should throw if authorization header is not well-formatted jwt', function(done) {
     var app = koa();
 
-    app.use(koajwt({secret: 'shhhh'}));
+    app.use(koajwt({ secret: 'shhhh' }));
     request(app.listen())
-    .get('/')
-    .set('Authorization', 'Bearer wrongjwt')
-    .expect(401)
-    .expect('Invalid token\n')
-    .end(done);
+      .get('/')
+      .set('Authorization', 'Bearer wrongjwt')
+      .expect(401)
+      .expect('Invalid token\n')
+      .end(done);
   });
 
   it('should throw if authorization header is not valid jwt', function(done) {
@@ -48,14 +48,14 @@ describe('failure tests', function() {
 
     var app = koa();
 
-    app.use(koajwt({secret: 'different-shhhh', debug: true}));
+    app.use(koajwt({ secret: 'different-shhhh', debug: true }));
     request(app.listen())
-    .get('/')
-    .set('Authorization', 'Bearer ' + token)
-    .expect(401)
-    .expect('Invalid token - invalid signature\n')
-    .end(done);
-    //   assert.equal(err.message, 'invalid signature');
+      .get('/')
+      .set('Authorization', 'Bearer ' + token)
+      .expect(401)
+      .expect('Invalid token - invalid signature\n')
+      .end(done);
+      //   assert.equal(err.message, 'invalid signature');
   });
 
   it('should throw if opts.cookies is set and the specified cookie is not well-formatted jwt', function(done) {
@@ -64,17 +64,17 @@ describe('failure tests', function() {
 
     var app = koa();
 
-    app.use(koajwt({secret: secret, cookie: 'jwt'}));
+    app.use(koajwt({ secret: secret, cookie: 'jwt' }));
     app.use(function* (next) {
       this.body = this.state.user;
     });
 
     request(app.listen())
-    .get('/')
-    .set('Cookie', 'jwt=bad' + token + ';')
-    .expect(401)
-    .expect('Invalid token\n')
-    .end(done);
+      .get('/')
+      .set('Cookie', 'jwt=bad' + token + ';')
+      .expect(401)
+      .expect('Invalid token\n')
+      .end(done);
 
   });
 
@@ -84,13 +84,13 @@ describe('failure tests', function() {
 
     var app = koa();
 
-    app.use(koajwt({secret: 'shhhhhh', audience: 'not-expected-audience', debug: true}));
+    app.use(koajwt({ secret: 'shhhhhh', audience: 'not-expected-audience', debug: true }));
     request(app.listen())
-    .get('/')
-    .set('Authorization', 'Bearer ' + token)
-    .expect(401)
-    .expect('Invalid token - jwt audience invalid. expected: not-expected-audience\n')
-    .end(done);
+      .get('/')
+      .set('Authorization', 'Bearer ' + token)
+      .expect(401)
+      .expect('Invalid token - jwt audience invalid. expected: not-expected-audience\n')
+      .end(done);
   });
 
   it('should throw if token is expired', function(done) {
@@ -99,106 +99,106 @@ describe('failure tests', function() {
 
     var app = koa();
 
-    app.use(koajwt({secret: 'shhhhhh', debug: true}));
+    app.use(koajwt({ secret: 'shhhhhh', debug: true }));
     request(app.listen())
-    .get('/')
-    .set('Authorization', 'Bearer ' + token)
-    .expect(401)
-    .expect('Invalid token - jwt expired\n')
-    .end(done);
+      .get('/')
+      .set('Authorization', 'Bearer ' + token)
+      .expect(401)
+      .expect('Invalid token - jwt expired\n')
+      .end(done);
   });
 
   it('should throw if token issuer is wrong', function(done) {
     var secret = 'shhhhhh';
-    var token = koajwt.sign({foo: 'bar', iss: 'http://foo'}, secret);
+    var token = koajwt.sign({foo: 'bar', iss: 'http://foo' }, secret);
 
     var app = koa();
 
-    app.use(koajwt({secret: 'shhhhhh', issuer: 'http://wrong', debug: true}));
+    app.use(koajwt({ secret: 'shhhhhh', issuer: 'http://wrong', debug: true }));
     request(app.listen())
-    .get('/')
-    .set('Authorization', 'Bearer ' + token)
-    .expect(401)
-    .expect('Invalid token - jwt issuer invalid. expected: http://wrong\n')
-    .end(done);
+      .get('/')
+      .set('Authorization', 'Bearer ' + token)
+      .expect(401)
+      .expect('Invalid token - jwt issuer invalid. expected: http://wrong\n')
+      .end(done);
   });
 
-  it('should throw if secret neither provide by options and middleware', function(done) {
+  it('should throw if secret neither provide by options and middleware', function (done) {
     var secret = 'shhhhhh';
-    var token = koajwt.sign({foo: 'bar', iss: 'http://foo'}, secret);
+    var token = koajwt.sign({foo: 'bar', iss: 'http://foo' }, secret);
 
     var app = koa();
 
     app.use(koajwt({debug: true}));
     request(app.listen())
-    .get('/')
-    .set('Authorization', 'Bearer ' + token)
-    .expect(401)
-    .expect('Invalid secret\n')
-    .end(done);
+      .get('/')
+      .set('Authorization', 'Bearer ' + token)
+      .expect(401)
+      .expect('Invalid secret\n')
+      .end(done);
   });
 
-  it('should throw if secret both provide by options(right secret) and middleware(wrong secret)', function(done) {
+  it('should throw if secret both provide by options(right secret) and middleware(wrong secret)', function (done) {
     var secret = 'shhhhhh';
-    var token = koajwt.sign({foo: 'bar', iss: 'http://foo'}, secret);
+    var token = koajwt.sign({foo: 'bar', iss: 'http://foo' }, secret);
 
     var app = koa();
 
     app.use(koajwt({secret: 'wrong secret', debug: true}));
     request(app.listen())
-    .get('/')
-    .set('Authorization', 'Bearer ' + token)
-    .expect(401)
-    .expect('Invalid token - invalid signature\n')
-    .end(done);
+      .get('/')
+      .set('Authorization', 'Bearer ' + token)
+      .expect(401)
+      .expect('Invalid token - invalid signature\n')
+      .end(done);
   });
 
 });
 
-describe('passthrough tests', function() {
+describe('passthrough tests', function () {
   it('should continue if `passthrough` is true', function(done) {
     var app = koa();
 
-    app.use(koajwt({secret: 'shhhhhh', passthrough: true, debug: true}));
+    app.use(koajwt({ secret: 'shhhhhh', passthrough: true, debug: true }));
     app.use(function* (next) {
       this.body = this.state.user;
     });
 
     request(app.listen())
-    .get('/')
-    .expect(204) // No content
-    .expect('')
-    .end(done);
+      .get('/')
+      .expect(204) // No content
+      .expect('')
+      .end(done);
   });
 
-  it('should continue if `passthrough` is a RegExp and the path matches', function(done) {
+  it('should continue if `passthrough` is a RegExp and the path matches', function (done) {
     var app = koa();
 
-    app.use(koajwt({secret: 'shhhhhh', passthrough: /^\/passthrough/, debug: true}));
+    app.use(koajwt({ secret: 'shhhhhh', passthrough: /^\/passthrough/, debug: true }));
     app.use(function* (next) {
       this.body = this.state.user;
     });
 
     request(app.listen())
-    .get('/passthrough')
-    .expect(204) // No content
-    .expect('')
-    .end(done);
+      .get('/passthrough')
+      .expect(204) // No content
+      .expect('')
+      .end(done);
   });
 
-  it('should not continue if `passthrough` is a RegExp and the path does not match', function(done) {
+  it('should not continue if `passthrough` is a RegExp and the path does not match', function (done) {
     var app = koa();
 
-    app.use(koajwt({secret: 'shhhhhh', passthrough: /^\/passthrough/, debug: true}));
+    app.use(koajwt({ secret: 'shhhhhh', passthrough: /^\/passthrough/, debug: true }));
     app.use(function* (next) {
       this.body = this.state.user;
     });
 
     request(app.listen())
-    .get('/dontpassthrough')
-    .expect(401)
-    .expect('No Authorization header found\n')
-    .end(done);
+      .get('/dontpassthrough')
+      .expect(401)
+      .expect('No Authorization header found\n')
+      .end(done);
   });
 });
 
@@ -214,7 +214,7 @@ describe('success tests', function() {
 
     var app = koa();
 
-    app.use(koajwt({secret: secret}));
+    app.use(koajwt({ secret: secret }));
     app.use(function* (next) {
       this.body = this.state.user;
     });
@@ -238,17 +238,17 @@ describe('success tests', function() {
 
     var app = koa();
 
-    app.use(koajwt({secret: secret, cookie: 'jwt'}));
+    app.use(koajwt({ secret: secret, cookie: 'jwt' }));
     app.use(function* (next) {
       this.body = this.state.user;
     });
 
     request(app.listen())
-    .get('/')
-    .set('Cookie', 'jwt=' + token + ';')
-    .expect(200)
-    .expect(validUserResponse)
-    .end(done);
+      .get('/')
+      .set('Cookie', 'jwt=' + token + ';')
+      .expect(200)
+      .expect(validUserResponse)
+      .end(done);
 
   });
 
@@ -286,7 +286,7 @@ describe('success tests', function() {
 
     var app = koa();
 
-    app.use(koajwt({secret: secret, key: 'jwtdata'}));
+    app.use(koajwt({ secret: secret, key: 'jwtdata' }));
     app.use(function* (next) {
       this.body = this.state.jwtdata;
     });
@@ -300,7 +300,7 @@ describe('success tests', function() {
 
   });
 
-  it('should work if secret is provided by middleware', function(done) {
+  it('should work if secret is provided by middleware', function (done) {
     var validUserResponse = function(res) {
       if (!(res.body.foo === 'bar')) return "Wrong user";
     };
@@ -320,14 +320,14 @@ describe('success tests', function() {
     });
 
     request(app.listen())
-    .get('/')
-    .set('Authorization', 'Bearer ' + token)
-    .expect(200)
-    .expect(validUserResponse)
-    .end(done);
+      .get('/')
+      .set('Authorization', 'Bearer ' + token)
+      .expect(200)
+      .expect(validUserResponse)
+      .end(done);
   });
 
-  it('should use middleware secret if both middleware and options provided', function(done) {
+  it('should use middleware secret if both middleware and options provided', function (done) {
     var validUserResponse = function(res) {
       if (!(res.body.foo === 'bar')) return "Wrong user";
     };
@@ -347,15 +347,15 @@ describe('success tests', function() {
     });
 
     request(app.listen())
-    .get('/')
-    .set('Authorization', 'Bearer ' + token)
-    .expect(200)
-    .expect(validUserResponse)
-    .end(done);
+      .get('/')
+      .set('Authorization', 'Bearer ' + token)
+      .expect(200)
+      .expect(validUserResponse)
+      .end(done);
   });
 });
 
-describe('unless tests', function() {
+describe('unless tests', function () {
 
   it('should pass if the route is excluded', function(done) {
     var validUserResponse = function(res) {
@@ -367,17 +367,17 @@ describe('unless tests', function() {
 
     var app = koa();
 
-    app.use(koajwt({secret: secret}).unless({path: ['/public']}));
+    app.use(koajwt({ secret: secret }).unless({ path: ['/public']}));
     app.use(function* (next) {
-      this.body = {success: true};
+      this.body = { success: true };
     });
 
     request(app.listen())
-    .get('/public')
-    .set('Authorization', 'wrong')
-    .expect(200)
-    .expect(validUserResponse)
-    .end(done);
+      .get('/public')
+      .set('Authorization', 'wrong')
+      .expect(200)
+      .expect(validUserResponse)
+      .end(done);
   });
 
   it('should fail if the route is not excluded', function(done) {
@@ -386,17 +386,17 @@ describe('unless tests', function() {
 
     var app = koa();
 
-    app.use(koajwt({secret: secret}).unless({path: ['/public']}));
+    app.use(koajwt({ secret: secret }).unless({ path: ['/public']}));
     app.use(function* (next) {
-      this.body = {success: true};
+      this.body = { success: true };
     });
 
     request(app.listen())
-    .get('/private')
-    .set('Authorization', 'wrong')
-    .expect(401)
-    .expect('Bad Authorization header format. Format is "Authorization: Bearer <token>"\n')
-    .end(done);
+      .get('/private')
+      .set('Authorization', 'wrong')
+      .expect(401)
+      .expect('Bad Authorization header format. Format is "Authorization: Bearer <token>"\n')
+      .end(done);
   });
 
   it('should pass if the route is not excluded and the token is present', function(done) {
@@ -409,17 +409,17 @@ describe('unless tests', function() {
 
     var app = koa();
 
-    app.use(koajwt({secret: secret, key: 'jwtdata'}).unless({path: ['/public']}));
+    app.use(koajwt({ secret: secret, key: 'jwtdata' }).unless({ path: ['/public']}));
     app.use(function* (next) {
       this.body = this.state.jwtdata;
     });
 
     request(app.listen())
-    .get('/')
-    .set('Authorization', 'Bearer ' + token)
-    .expect(200)
-    .expect(validUserResponse)
-    .end(done);
+      .get('/')
+      .set('Authorization', 'Bearer ' + token)
+      .expect(200)
+      .expect(validUserResponse)
+      .end(done);
 
   });
 });


### PR DESCRIPTION
Changes:
- passthrough can now also be a RegExp, which matches against the incoming url. This allows you to only allow passthrough on certain routes, for example so you can have a route that shows login status via JSON.
- Cookie auth now falls back to header authentication if no cookie is present.
- When using opts.cookie, a more specific error message is shown if neither cookie nor Auth Header are present.
