### PR TITLE
Fixed "invalid secret" test

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ module.exports = function(opts) {
 
     secret = (this.state && this.state.secret) ? this.state.secret : opts.secret;
     if (!secret) {
-      this.throw(500, 'Invalid secret\n');
+      this.throw(500, 'Invalid secret\n', { expose: true });
     }
 
     try {

--- a/test.js
+++ b/test.js
@@ -133,7 +133,7 @@ describe('failure tests', function () {
     request(app.listen())
       .get('/')
       .set('Authorization', 'Bearer ' + token)
-      .expect(401)
+      .expect(500)
       .expect('Invalid secret\n')
       .end(done);
   });
@@ -370,5 +370,5 @@ describe('unless tests', function () {
       .end(done);
 
   });
-  
+
 });


### PR DESCRIPTION
The test "should throw if secret neither provide by options and
middleware" was failing because a 500 error was being thrown with out
having a `expose: true` property set.

The assertion for the Invalid Secret error `.expect('Invalid secret\n')` would fail because koa was returning "Internal Server Error" snic all error codes 500 or greater have `expose: false` set by default.

(See more at [jshttp/http-errors](https://github.com/jshttp/http-errors) which is what koa context.throw() uses behind the scenes).