### PR TITLE
Add getToken functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ token. If the token is valid, `ctx.state.user` (by default) will be set
 with the JSON object decoded to be used by later middleware for
 authorization and access control.
 
-The token is normally provided in a HTTP header (`Authorization`), but it 
+The token is normally provided in a HTTP header (`Authorization`), but it
 can also be provided in a cookie by setting the `opts.cookie` option
-to the name of the cookie that contains the token. 
+to the name of the cookie that contains the token. Custom token retrieval can also be done through the `opts.getToken` option. The provided function is called in the normal Koa context and should return the retrieved token.
 
-Normally you provide a single shared secret in `opts.secret`, but another 
+Normally you provide a single shared secret in `opts.secret`, but another
 alternative is to have an earlier middleware set `ctx.state.secret`,
 typically per request. If this property exists, it will be used instead
 of the one in `opts.secret`.

--- a/index.js
+++ b/index.js
@@ -13,7 +13,9 @@ module.exports = function(opts) {
   var middleware = function *jwt(next) {
     var token, msg, user, parts, scheme, credentials, secret;
 
-    if (opts.cookie && this.cookies.get(opts.cookie)) {
+    if (opts.getToken) {
+      token = opts.getToken.call(this);
+    } else if (opts.cookie && this.cookies.get(opts.cookie)) {
       token = this.cookies.get(opts.cookie);
 
     } else if (this.header.authorization) {


### PR DESCRIPTION
This adds a `opts.getToken` option.

This option takes precedence over other token retrieval options (headers, cookies, etc.). Users can pass a function that will be called with `this` being the Koa context and should return with the JWT to verify.

This would close #30 