### PR TITLE
Migrate to Koa v2 middleware syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,31 +57,29 @@ of the one in `opts.secret`.
 ## Example
 
 ```js
-var koa = require('koa');
+var Koa = require('koa');
 var jwt = require('koa-jwt');
 
-var app = koa();
+var app = new Koa();
 
 // Custom 401 handling if you don't want to expose koa-jwt errors to users
-app.use(function *(next){
-  try {
-    yield next;
-  } catch (err) {
+app.use(function(ctx, next){
+  return next().catch((err) => {
     if (401 == err.status) {
-      this.status = 401;
-      this.body = 'Protected resource, use Authorization header to get access\n';
+      ctx.status = 401;
+      ctx.body = 'Protected resource, use Authorization header to get access\n';
     } else {
       throw err;
     }
-  }
+  });
 });
 
 // Unprotected middleware
-app.use(function *(next){
-  if (this.url.match(/^\/public/)) {
-    this.body = 'unprotected\n';
+app.use(function(ctx, next){
+  if (ctx.url.match(/^\/public/)) {
+    ctx.body = 'unprotected\n';
   } else {
-    yield next;
+    return next();
   }
 });
 
@@ -89,9 +87,9 @@ app.use(function *(next){
 app.use(jwt({ secret: 'shared-secret' }));
 
 // Protected middleware
-app.use(function *(){
-  if (this.url.match(/^\/api/)) {
-    this.body = 'protected\n';
+app.use(function(ctx){
+  if (ctx.url.match(/^\/api/)) {
+    ctx.body = 'protected\n';
   }
 });
 
@@ -105,25 +103,25 @@ Alternatively you can conditionally run the `jwt` middleware under certain condi
 var koa = require('koa');
 var jwt = require('koa-jwt');
 
-var app = koa();
+var app = new Koa();
 
 // Middleware below this line is only reached if JWT token is valid
 // unless the URL starts with '/public'
 app.use(jwt({ secret: 'shared-secret' }).unless({ path: [/^\/public/] }));
 
 // Unprotected middleware
-app.use(function *(next){
-  if (this.url.match(/^\/public/)) {
-    this.body = 'unprotected\n';
+app.use(function(ctx, next){
+  if (ctx.url.match(/^\/public/)) {
+    ctx.body = 'unprotected\n';
   } else {
-    yield next;
+    return next();
   }
 });
 
 // Protected middleware
-app.use(function *(){
-  if (this.url.match(/^\/api/)) {
-    this.body = 'protected\n';
+app.use(function(ctx){
+  if (ctx.url.match(/^\/api/)) {
+    ctx.body = 'protected\n';
   }
 });
 

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 'use strict';
-var assert    = require('assert');
-var Promise   = require('bluebird');
-var JWT       = Promise.promisifyAll(require('jsonwebtoken'));
-var unless    = require('koa-unless');
-var util      = require('util');
+const assert    = require('assert');
+const Promise   = require('bluebird');
+const JWT       = Promise.promisifyAll(require('jsonwebtoken'));
+const unless    = require('koa-unless');
+const util      = require('util');
 
 module.exports = function(opts) {
   opts = opts || {};

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 var assert    = require('assert');
-var JWT       = require('jsonwebtoken');
+var Promise   = require('bluebird');
+var JWT       = Promise.promisifyAll(require('jsonwebtoken'));
 var unless    = require('koa-unless');
 var util      = require('util');
 
@@ -15,10 +16,10 @@ module.exports = function(opts) {
   }
 
   var middleware = function jwt(ctx, next) {
-    var token, msg, user, parts, scheme, credentials, secret;
+    var token, parts, scheme, credentials, secret;
 
     for (var i = 0; i < tokenResolvers.length; i++) {
-      var output = tokenResolvers[i].call(ctx, opts);
+      var output = tokenResolvers[i](ctx, opts);
 
       if (output) {
         token = output;
@@ -35,19 +36,18 @@ module.exports = function(opts) {
       ctx.throw(500, 'Invalid secret\n');
     }
 
-    try {
-      user = JWT.verify(token, secret, opts);
-    } catch(e) {
-      msg = 'Invalid token' + (opts.debug ? ' - ' + e.message + '\n' : '\n');
-    }
-
-    if (user || opts.passthrough) {
-      ctx.state = ctx.state || {};
-      ctx.state[opts.key] = user;
-      return next();
-    } else {
-      ctx.throw(401, msg);
-    }
+    return JWT.verifyAsync(token, secret, opts)
+      .then((user) => {
+        ctx.state = ctx.state || {};
+        ctx.state[opts.key] = user;
+      })
+      .catch((e) => {
+        if (!opts.passthrough) {
+          let msg = 'Invalid token' + (opts.debug ? ' - ' + e.message + '\n' : '\n');
+          return ctx.throw(401, msg);
+        }
+      })
+      .then(() => next())
   };
 
   middleware.unless = unless;
@@ -61,17 +61,16 @@ module.exports = function(opts) {
  *
  * This function checks the Authorization header for a `Bearer <token>` pattern and return the token section
  *
- * @this The ctx object passed to the middleware
- *
- * @param  {object}      opts The middleware's options
- * @return {String|null}      The resolved token or null if not found
+ * @param {Object}        ctx  The ctx object passed to the middleware
+ * @param {Object}        opts The middleware's options
+ * @return {String|null}  The resolved token or null if not found
  */
-function resolveAuthorizationHeader(opts) {
-  if (!this.header || !this.header.authorization) {
+function resolveAuthorizationHeader(ctx, opts) {
+  if (!ctx.header || !ctx.header.authorization) {
     return;
   }
 
-  var parts = this.header.authorization.split(' ');
+  var parts = ctx.header.authorization.split(' ');
 
   if (parts.length === 2) {
     var scheme = parts[0];
@@ -82,7 +81,7 @@ function resolveAuthorizationHeader(opts) {
     }
   } else {
     if (!opts.passthrough) {
-      this.throw(401, 'Bad Authorization header format. Format is "Authorization: Bearer <token>"\n');
+      ctx.throw(401, 'Bad Authorization header format. Format is "Authorization: Bearer <token>"\n');
     }
   }
 }
@@ -93,13 +92,12 @@ function resolveAuthorizationHeader(opts) {
  *
  * This function uses the opts.cookie option to retrieve the token
  *
- * @this The ctx object passed to the middleware
- *
- * @param  {object}      opts This middleware's options
- * @return {String|null}      The resolved token or null if not found
+ * @param {Object}        ctx  The ctx object passed to the middleware
+ * @param {Object}        opts This middleware's options
+ * @return {String|null}  The resolved token or null if not found
  */
-function resolveCookies(opts) {
-  if (opts.cookie && this.cookies.get(opts.cookie)) {
-    return this.cookies.get(opts.cookie);
+function resolveCookies(ctx, opts) {
+  if (opts.cookie && ctx.cookies.get(opts.cookie)) {
+    return ctx.cookies.get(opts.cookie);
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   ],
   "main": "./lib",
   "dependencies": {
+    "bluebird": "^3.3.5",
     "jsonwebtoken": "^5.7.0",
     "koa-unless": "0.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "bluebird": "^3.3.5",
     "jsonwebtoken": "^5.7.0",
-    "koa-unless": "nfantone/koa-unless#next"
+    "koa-unless": "^1.0.0"
   },
   "devDependencies": {
     "koa": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "bluebird": "^3.3.5",
     "jsonwebtoken": "^5.7.0",
-    "koa-unless": "0.0.1"
+    "koa-unless": "nfantone/koa-unless#next"
   },
   "devDependencies": {
     "koa": "^2.0.0",
@@ -47,7 +47,7 @@
     "supertest": "~0.15.0"
   },
   "engines": {
-    "node": ">= 0.12.0"
+    "node": ">= 4.0.0"
   },
   "scripts": {
     "test": "make test"

--- a/package.json
+++ b/package.json
@@ -37,12 +37,11 @@
   ],
   "main": "./lib",
   "dependencies": {
-    "jsonwebtoken": "5.x.x",
-    "koa-unless": "0.0.1",
-    "thunkify": "~2.1.x"
+    "jsonwebtoken": "^5.7.0",
+    "koa-unless": "0.0.1"
   },
   "devDependencies": {
-    "koa": "koajs/koa",
+    "koa": "^2.0.0",
     "mocha": "~2.2.1",
     "supertest": "~0.15.0"
   },

--- a/test-server.js
+++ b/test-server.js
@@ -1,13 +1,13 @@
 'use strict';
-var Koa = require('koa');
-var koajwt = require('./index');
-var jwt = require('jsonwebtoken');
+const Koa = require('koa');
+const koajwt = require('./index');
+const jwt = require('jsonwebtoken');
 
-var profile = {
+const profile = {
   id: 123
 };
 
-var token = jwt.sign(profile, 'secret', { expiresInMinutes: 60*5 });
+const TOKEN = jwt.sign(profile, 'secret', { expiresInMinutes: 60*5 });
 
 console.log('Starting koa-jwt test server on http://localhost:3000/');
 console.log('');
@@ -15,7 +15,7 @@ console.log('You can test the server by issuing curl commands like the following
 console.log('')
 console.log('  curl http://localhost:3000/public/foo            # should succeed (return "unprotected")');
 console.log('  curl http://localhost:3000/api/foo               # should fail (return "401 Unauthorized ...")');
-console.log('  curl -H "Authorization: Bearer ' + token + '" http://localhost:3000/api/foo   # should succeed (return "protected")');
+console.log('  curl -H "Authorization: Bearer ' + TOKEN + '" http://localhost:3000/api/foo   # should succeed (return "protected")');
 console.log('')
 
 var app = new Koa();

--- a/test.js
+++ b/test.js
@@ -1,3 +1,4 @@
+'use strict';
 var TOKEN = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJmb28iOiJiYXIiLCJpYXQiOjE0MjY1NDY5MTl9.ETgkTn8BaxIX4YqvUWVFPmum3moNZ7oARZtSBXb_vP4';
 
 var Koa     = require('koa');
@@ -34,8 +35,8 @@ describe('failure tests', function () {
   it('should allow provided getToken function to throw', function(done) {
     var app = new Koa();
 
-    app.use(koajwt({ secret: 'shhhh', getToken: function() {
-      this.throw(401, 'Bad Authorization\n');
+    app.use(koajwt({ secret: 'shhhh', getToken: function(ctx) {
+      ctx.throw(401, 'Bad Authorization\n');
     } }));
     request(app.listen())
       .get('/')
@@ -236,8 +237,8 @@ describe('success tests', function () {
     var token = jwt.sign({foo: 'bar'}, secret);
 
     var app = new Koa();
-    app.use(koajwt({ secret: secret, getToken: function() {
-      return this.request.query.token;
+    app.use(koajwt({ secret: secret, getToken: function(ctx) {
+      return ctx.request.query.token;
     }}));
     app.use(function(ctx) {
       ctx.body = ctx.state.user;

--- a/test.js
+++ b/test.js
@@ -1,12 +1,12 @@
 'use strict';
-var TOKEN = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJmb28iOiJiYXIiLCJpYXQiOjE0MjY1NDY5MTl9.ETgkTn8BaxIX4YqvUWVFPmum3moNZ7oARZtSBXb_vP4';
+const TOKEN = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJmb28iOiJiYXIiLCJpYXQiOjE0MjY1NDY5MTl9.ETgkTn8BaxIX4YqvUWVFPmum3moNZ7oARZtSBXb_vP4';
 
-var Koa     = require('koa');
-var request = require('supertest');
-var assert  = require('assert');
-var jwt = require('jsonwebtoken')
+const Koa     = require('koa');
+const request = require('supertest');
+const assert  = require('assert');
+const jwt     = require('jsonwebtoken');
 
-var koajwt  = require('./index');
+const koajwt  = require('./index');
 
 describe('failure tests', function () {
 

--- a/test.js
+++ b/test.js
@@ -1,15 +1,16 @@
 var TOKEN = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJmb28iOiJiYXIiLCJpYXQiOjE0MjY1NDY5MTl9.ETgkTn8BaxIX4YqvUWVFPmum3moNZ7oARZtSBXb_vP4';
 
-var koa     = require('koa');
+var Koa     = require('koa');
 var request = require('supertest');
 var assert  = require('assert');
+var jwt = require('jsonwebtoken')
 
 var koajwt  = require('./index');
 
 describe('failure tests', function () {
 
   it('should throw 401 if no authorization header', function(done) {
-    var app = koa();
+    var app = new Koa();
 
     app.use(koajwt({ secret: 'shhhh' }));
     request(app.listen())
@@ -19,7 +20,7 @@ describe('failure tests', function () {
   });
 
   it('should return 401 if authorization header is malformed', function(done) {
-    var app = koa();
+    var app = new Koa();
 
     app.use(koajwt({ secret: 'shhhh' }));
     request(app.listen())
@@ -31,7 +32,7 @@ describe('failure tests', function () {
   });
 
   it('should allow provided getToken function to throw', function(done) {
-    var app = koa();
+    var app = new Koa();
 
     app.use(koajwt({ secret: 'shhhh', getToken: function() {
       this.throw(401, 'Bad Authorization\n');
@@ -44,11 +45,11 @@ describe('failure tests', function () {
   });
 
   it('should throw if getToken function returns invalid jwt', function(done) {
-    var app = koa();
+    var app = new Koa();
 
     app.use(koajwt({ secret: 'shhhhhh', getToken: function() {
       var secret = 'bad';
-      return koajwt.sign({foo: 'bar'}, secret);
+      return jwt.sign({foo: 'bar'}, secret);
     } }));
     request(app.listen())
       .get('/')
@@ -58,7 +59,7 @@ describe('failure tests', function () {
   });
 
   it('should throw if authorization header is not well-formatted jwt', function(done) {
-    var app = koa();
+    var app = new Koa();
 
     app.use(koajwt({ secret: 'shhhh' }));
     request(app.listen())
@@ -71,9 +72,9 @@ describe('failure tests', function () {
 
   it('should throw if authorization header is not valid jwt', function(done) {
     var secret = 'shhhhhh';
-    var token = koajwt.sign({foo: 'bar'}, secret);
+    var token = jwt.sign({foo: 'bar'}, secret);
 
-    var app = koa();
+    var app = new Koa();
 
     app.use(koajwt({ secret: 'different-shhhh', debug: true }));
     request(app.listen())
@@ -87,13 +88,13 @@ describe('failure tests', function () {
 
   it('should throw if opts.cookies is set and the specified cookie is not well-formatted jwt', function(done) {
     var secret = 'shhhhhh';
-    var token = koajwt.sign({foo: 'bar'}, secret);
+    var token = jwt.sign({foo: 'bar'}, secret);
 
-    var app = koa();
+    var app = new Koa();
 
     app.use(koajwt({ secret: secret, cookie: 'jwt' }));
-    app.use(function* (next) {
-      this.body = this.state.user;
+    app.use(function (ctx, next) {
+      ctx.body = ctx.state.user;
     });
 
     request(app.listen())
@@ -107,9 +108,9 @@ describe('failure tests', function () {
 
   it('should throw if audience is not expected', function(done) {
     var secret = 'shhhhhh';
-    var token = koajwt.sign({foo: 'bar', aud: 'expected-audience'}, secret);
+    var token = jwt.sign({foo: 'bar', aud: 'expected-audience'}, secret);
 
-    var app = koa();
+    var app = new Koa();
 
     app.use(koajwt({ secret: 'shhhhhh', audience: 'not-expected-audience', debug: true }));
     request(app.listen())
@@ -122,9 +123,9 @@ describe('failure tests', function () {
 
   it('should throw if token is expired', function(done) {
     var secret = 'shhhhhh';
-    var token = koajwt.sign({foo: 'bar', exp: 1382412921 }, secret);
+    var token = jwt.sign({foo: 'bar', exp: 1382412921 }, secret);
 
-    var app = koa();
+    var app = new Koa();
 
     app.use(koajwt({ secret: 'shhhhhh', debug: true }));
     request(app.listen())
@@ -137,9 +138,9 @@ describe('failure tests', function () {
 
   it('should throw if token issuer is wrong', function(done) {
     var secret = 'shhhhhh';
-    var token = koajwt.sign({foo: 'bar', iss: 'http://foo' }, secret);
+    var token = jwt.sign({foo: 'bar', iss: 'http://foo' }, secret);
 
-    var app = koa();
+    var app = new Koa();
 
     app.use(koajwt({ secret: 'shhhhhh', issuer: 'http://wrong', debug: true }));
     request(app.listen())
@@ -152,9 +153,9 @@ describe('failure tests', function () {
 
   it('should throw if secret neither provide by options and middleware', function (done) {
     var secret = 'shhhhhh';
-    var token = koajwt.sign({foo: 'bar', iss: 'http://foo' }, secret);
+    var token = jwt.sign({foo: 'bar', iss: 'http://foo' }, secret);
 
-    var app = koa();
+    var app = new Koa();
 
     app.use(koajwt({debug: true}));
     request(app.listen())
@@ -167,9 +168,9 @@ describe('failure tests', function () {
 
   it('should throw if secret both provide by options(right secret) and middleware(wrong secret)', function (done) {
     var secret = 'shhhhhh';
-    var token = koajwt.sign({foo: 'bar', iss: 'http://foo' }, secret);
+    var token = jwt.sign({foo: 'bar', iss: 'http://foo' }, secret);
 
-    var app = koa();
+    var app = new Koa();
 
     app.use(koajwt({secret: 'wrong secret', debug: true}));
     request(app.listen())
@@ -184,11 +185,11 @@ describe('failure tests', function () {
 
 describe('passthrough tests', function () {
   it('should continue if `passthrough` is true', function(done) {
-    var app = koa();
+    var app = new Koa();
 
     app.use(koajwt({ secret: 'shhhhhh', passthrough: true, debug: true }));
-    app.use(function* (next) {
-      this.body = this.state.user;
+    app.use(function (ctx) {
+      ctx.body = ctx.state.user;
     });
 
     request(app.listen())
@@ -208,13 +209,13 @@ describe('success tests', function () {
     }
 
     var secret = 'shhhhhh';
-    var token = koajwt.sign({foo: 'bar'}, secret);
+    var token = jwt.sign({foo: 'bar'}, secret);
 
-    var app = koa();
+    var app = new Koa();
 
     app.use(koajwt({ secret: secret }));
-    app.use(function* (next) {
-      this.body = this.state.user;
+    app.use(function (ctx) {
+      ctx.body = ctx.state.user;
     });
 
     request(app.listen())
@@ -232,14 +233,14 @@ describe('success tests', function () {
     }
 
     var secret = 'shhhhhh';
-    var token = koajwt.sign({foo: 'bar'}, secret);
+    var token = jwt.sign({foo: 'bar'}, secret);
 
-    var app = koa();
+    var app = new Koa();
     app.use(koajwt({ secret: secret, getToken: function() {
       return this.request.query.token;
     }}));
-    app.use(function* (next) {
-      this.body = this.state.user;
+    app.use(function(ctx) {
+      ctx.body = ctx.state.user;
     });
 
     request(app.listen())
@@ -255,14 +256,14 @@ describe('success tests', function () {
     }
 
     var secret = 'shhhhhh';
-    var token = koajwt.sign({foo: 'bar'}, secret);
+    var token = jwt.sign({foo: 'bar'}, secret);
 
-    var invalidToken = koajwt.sign({foo: 'bar'}, 'badSecret');
+    var invalidToken = jwt.sign({foo: 'bar'}, 'badSecret');
 
-    var app = koa();
+    var app = new Koa();
     app.use(koajwt({ secret: secret, cookie: 'jwt'}));
-    app.use(function* (next) {
-      this.body = this.state.user;
+    app.use(function (ctx) {
+      ctx.body = ctx.state.user;
     });
 
     request(app.listen())
@@ -280,13 +281,13 @@ describe('success tests', function () {
     }
 
     var secret = 'shhhhhh';
-    var token = koajwt.sign({foo: 'bar'}, secret);
+    var token = jwt.sign({foo: 'bar'}, secret);
 
-    var app = koa();
+    var app = new Koa();
 
     app.use(koajwt({ secret: secret, cookie: 'jwt' }));
-    app.use(function* (next) {
-      this.body = this.state.user;
+    app.use(function(ctx) {
+      ctx.body = ctx.state.user;
     });
 
     request(app.listen())
@@ -304,13 +305,13 @@ describe('success tests', function () {
     }
 
     var secret = 'shhhhhh';
-    var token = koajwt.sign({foo: 'bar'}, secret);
+    var token = jwt.sign({foo: 'bar'}, secret);
 
-    var app = koa();
+    var app = new Koa();
 
     app.use(koajwt({ secret: secret, key: 'jwtdata' }));
-    app.use(function* (next) {
-      this.body = this.state.jwtdata;
+    app.use(function (ctx) {
+      ctx.body = ctx.state.jwtdata;
     });
 
     request(app.listen())
@@ -328,17 +329,17 @@ describe('success tests', function () {
     };
 
     var secret = 'shhhhhh';
-    var token = koajwt.sign({foo: 'bar'}, secret);
+    var token = jwt.sign({foo: 'bar'}, secret);
 
-    var app = koa();
+    var app = new Koa();
 
-    app.use(function *(next) {
-        this.state.secret = secret;
-        yield next;
+    app.use(function (ctx, next) {
+        ctx.state.secret = secret;
+        return next();
     });
     app.use(koajwt());
-    app.use(function* (next) {
-      this.body = this.state.user;
+    app.use(function(ctx) {
+      ctx.body = ctx.state.user;
     });
 
     request(app.listen())
@@ -356,17 +357,17 @@ describe('success tests', function () {
     };
 
     var secret = 'shhhhhh';
-    var token = koajwt.sign({foo: 'bar'}, secret);
+    var token = jwt.sign({foo: 'bar'}, secret);
 
-    var app = koa();
+    var app = new Koa();
 
-    app.use(function *(next) {
-      this.state.secret = secret;
-      yield next;
+    app.use(function(ctx, next) {
+      ctx.state.secret = secret;
+      return next();
     });
     app.use(koajwt({secret: 'wrong secret'}));
-    app.use(function* (next) {
-      this.body = this.state.user;
+    app.use(function (ctx) {
+      ctx.body = ctx.state.user;
     });
 
     request(app.listen())
@@ -386,13 +387,13 @@ describe('unless tests', function () {
     };
 
     var secret = 'shhhhhh';
-    var token = koajwt.sign({foo: 'bar'}, secret);
+    var token = jwt.sign({foo: 'bar'}, secret);
 
-    var app = koa();
+    var app = new Koa();
 
     app.use(koajwt({ secret: secret }).unless({ path: ['/public']}));
-    app.use(function* (next) {
-      this.body = { success: true };
+    app.use(function(ctx) {
+      ctx.body = { success: true };
     });
 
     request(app.listen())
@@ -405,13 +406,13 @@ describe('unless tests', function () {
 
   it('should fail if the route is not excluded', function(done) {
     var secret = 'shhhhhh';
-    var token = koajwt.sign({foo: 'bar'}, secret);
+    var token = jwt.sign({foo: 'bar'}, secret);
 
-    var app = koa();
+    var app = new Koa();
 
     app.use(koajwt({ secret: secret }).unless({ path: ['/public']}));
-    app.use(function* (next) {
-      this.body = { success: true };
+    app.use(function(ctx) {
+      ctx.body = { success: true };
     });
 
     request(app.listen())
@@ -428,13 +429,13 @@ describe('unless tests', function () {
     };
 
     var secret = 'shhhhhh';
-    var token = koajwt.sign({foo: 'bar'}, secret);
+    var token = jwt.sign({foo: 'bar'}, secret);
 
-    var app = koa();
+    var app = new Koa();
 
     app.use(koajwt({ secret: secret, key: 'jwtdata' }).unless({ path: ['/public']}));
-    app.use(function* (next) {
-      this.body = this.state.jwtdata;
+    app.use(function(ctx) {
+      ctx.body = ctx.state.jwtdata;
     });
 
     request(app.listen())


### PR DESCRIPTION
- Upgrade koa in `devDependencies` to `^2.0.0`.
- Remove generators in favor of promise-based middleware.
- Update all unit tests.