### PR TITLE
use current version of jsonwebtoken

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-jwt",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Koa JWT authentication middleware.",
   "keywords": [
     "auth",
@@ -37,7 +37,7 @@
   ],
   "main": "./lib",
   "dependencies": {
-    "jsonwebtoken": "5.x.x",
+    "jsonwebtoken": "6.x.x",
     "koa-unless": "0.0.1",
     "thunkify": "~2.1.x"
   },


### PR DESCRIPTION
callback for sign method of jsonwebtoken 5.x did not follow node convention (see [here](https://github.com/auth0/node-jsonwebtoken/issues/169)). updated jsonwebtoken to 6.x and bumped version patch number. 23/23 tests passing.
