### PR TITLE
Define custom user with passthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ app.use(jwt({ secret: 'shared-secret', passthrough: true }));
 ```
 This lets downstream middleware make decisions based on whether `ctx.state.user` is set.
 
+As an alternative, if you set `passthrough` to be an `Object` instead of a `boolean`, its value will be set as `ctx.state.user`. This is mostly useful during development while writing middlewares that relies on `ctx.state.user` to be present.
+
 
 If you prefer to use another ctx key for the decoded data, just pass in `key`, like so:
 ```js

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 'use strict';
-const assert    = require('assert');
-const Promise   = require('bluebird');
-const JWT       = Promise.promisifyAll(require('jsonwebtoken'));
-const unless    = require('koa-unless');
-const util      = require('util');
+const assert      = require('assert');
+const Promise     = require('bluebird');
+const JWT         = Promise.promisifyAll(require('jsonwebtoken'));
+const unless      = require('koa-unless');
+const isFunction  = require('lodash.isfunction');
 
 module.exports = function(opts) {
   opts = opts || {};
@@ -11,7 +11,7 @@ module.exports = function(opts) {
 
   var tokenResolvers = [resolveCookies, resolveAuthorizationHeader];
 
-  if (opts.getToken && util.isFunction(opts.getToken)) {
+  if (opts.getToken && isFunction(opts.getToken)) {
     tokenResolvers.unshift(opts.getToken);
   }
 

--- a/index.js
+++ b/index.js
@@ -18,14 +18,7 @@ module.exports = function(opts) {
   var middleware = function jwt(ctx, next) {
     var token, parts, scheme, credentials, secret;
 
-    for (var i = 0; i < tokenResolvers.length; i++) {
-      var output = tokenResolvers[i](ctx, opts);
-
-      if (output) {
-        token = output;
-        break;
-      }
-    }
+    tokenResolvers.find((resolver) => token = resolver(ctx, opts));
 
     if (!token && !opts.passthrough) {
       ctx.throw(401, 'No authentication token found\n');

--- a/index.js
+++ b/index.js
@@ -21,12 +21,12 @@ module.exports = function(opts) {
     tokenResolvers.find((resolver) => token = resolver(ctx, opts));
 
     if (!token && !opts.passthrough) {
-      ctx.throw(401, 'No authentication token found\n');
+      return ctx.throw(401, 'No authentication token found\n');
     }
 
     secret = (ctx.state && ctx.state.secret) ? ctx.state.secret : opts.secret;
     if (!secret) {
-      ctx.throw(401, 'Invalid secret\n');
+      return ctx.throw(401, 'Invalid secret\n');
     }
 
     return JWT.verifyAsync(token, secret, opts)

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const Promise     = require('bluebird');
 const JWT         = Promise.promisifyAll(require('jsonwebtoken'));
 const unless      = require('koa-unless');
 const isFunction  = require('lodash.isfunction');
+const isObject    = require('lodash.isobject');
 
 module.exports = function(opts) {
   opts = opts || {};
@@ -30,14 +31,16 @@ module.exports = function(opts) {
     }
 
     return JWT.verifyAsync(token, secret, opts)
-      .then((user) => {
-        ctx.state = ctx.state || {};
-        ctx.state[opts.key] = user;
-      })
+      .then((user) => setUser(ctx, opts, user))
       .catch((e) => {
         if (!opts.passthrough) {
           let msg = 'Invalid token' + (opts.debug ? ' - ' + e.message + '\n' : '\n');
           return ctx.throw(401, msg);
+        }
+      })
+      .then(() => {
+        if (isObject(opts.passthrough)) {
+          return setUser(ctx, opts, opts.passthrough);
         }
       })
       .then(() => next())
@@ -48,6 +51,18 @@ module.exports = function(opts) {
   return middleware;
 };
 
+/**
+ * Sets the authenticated user data onto `ctx.state[opts.key]`.
+ *
+ * @param {Object}    ctx  The ctx object passed to the middleware
+ * @param {Object}    opts The middleware's options
+ * @param {Object}    user User data to be set
+ */
+function setUser(ctx, opts, user) {
+  ctx.state = ctx.state || {};
+  ctx.state[opts.key] = user;
+  return ctx;
+}
 
 /**
  * resolveAuthorizationHeader - Attempts to parse the token from the Authorization header

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
   "dependencies": {
     "bluebird": "^3.3.5",
     "jsonwebtoken": "^6.2.0",
-    "koa-unless": "^1.0.0"
+    "koa-unless": "^1.0.0",
+    "lodash.isfunction": "^3.0.8",
+    "lodash.isobject": "^3.0.2"
   },
   "devDependencies": {
     "koa": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -38,13 +38,13 @@
   "main": "./lib",
   "dependencies": {
     "bluebird": "^3.3.5",
-    "jsonwebtoken": "^5.7.0",
+    "jsonwebtoken": "^6.2.0",
     "koa-unless": "^1.0.0"
   },
   "devDependencies": {
     "koa": "^2.0.0",
-    "mocha": "~2.2.1",
-    "supertest": "~0.15.0"
+    "mocha": "~2.4.5",
+    "supertest": "~1.2.0"
   },
   "engines": {
     "node": ">= 4.0.0"

--- a/test.js
+++ b/test.js
@@ -199,6 +199,21 @@ describe('passthrough tests', function () {
       .expect('')
       .end(done);
   });
+
+  it('should set user if `passthrough` is an object', function(done) {
+    var app = new Koa();
+
+    app.use(koajwt({ secret: 'shhhhhh', passthrough: { foo: 'bar' }, debug: true }));
+    app.use(function (ctx) {
+      ctx.body = ctx.state.user;
+    });
+
+    request(app.listen())
+      .get('/')
+      .expect(200)
+      .expect({ foo: 'bar' })
+      .end(done);
+  });
 });
 
 


### PR DESCRIPTION
- Upgrade outdated npm dependencies.
- Simplify `for` loop of `tokenResolvers`.
- Replace deprecated core `util` module usage with lodash functions.
- `opts.passthrough` may now be an `Object`. If it is, then `ctx.state.user` will point to that object, instead of leaving it as `undefined`. This is _very_ useful during development on middlewares that require authentication and the presence of `ctx.state.user`.
- Extend `README.md`.
- Add unit test for the new value admitted by `opts.passthrough`.
