### PR TITLE
Fix validation in resolveAuthorizationHeader

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,10 +83,10 @@ function resolveAuthorizationHeader(opts) {
     if (/^Bearer$/i.test(scheme)) {
       return credentials;
     }
-  } else {
-    if (!opts.passthrough) {
-      this.throw(401, 'Bad Authorization header format. Format is "Authorization: Bearer <token>"\n');
-    }
+  }
+
+  if (!opts.passthrough) {
+    this.throw(401, 'Bad Authorization header format. Format is "Authorization: Bearer <token>"\n');
   }
 }
 

--- a/test.js
+++ b/test.js
@@ -30,6 +30,18 @@ describe('failure tests', function () {
       .end(done);
   });
 
+  it('should return 401 if authorization header does not start with "Bearer "', function(done) {
+    var app = koa();
+
+    app.use(koajwt({ secret: 'shhhh' }));
+    request(app.listen())
+      .get('/')
+      .set('Authorization', 'Beer sometoken')
+      .expect(401)
+      .expect('Bad Authorization header format. Format is "Authorization: Bearer <token>"\n')
+      .end(done);
+  });
+
   it('should allow provided getToken function to throw', function(done) {
     var app = koa();
 


### PR DESCRIPTION
This PR fixes the check in the `resolveAuthorizationHeader` function. Before this commit, koa-jwt would eventually respond with `No authentication token found` when there was a malformed auth token like `Beer sometoken` 🍻 
