### PR TITLE
F/bnb exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ for a good introduction.
 Bnbsitter changed the status of exceptions returned by jwt to catch them more accurately.
 
 New status code:
+
 | Status code | koa-jwt exception                                                         | Bnbsitter exception                                |
 |-------------|---------------------------------------------------------------------------|----------------------------------------------------|
 | 401         | No authentication token found                                             | error.BadAuthorization.TokenNotFound               |

--- a/README.md
+++ b/README.md
@@ -9,6 +9,22 @@ in your [Koa](http://koajs.com/) (node.js) applications.
 See [this article](http://blog.auth0.com/2014/01/07/angularjs-authentication-with-cookies-vs-token/)
 for a good introduction.
 
+## Bnbsitter exceptions status
+
+Bnbsitter changed the status of exceptions returned by jwt to catch them more accurately.
+
+New status code:
+| Status code | koa-jwt exception                                                         | Bnbsitter exception                                |
+|-------------|---------------------------------------------------------------------------|----------------------------------------------------|
+| 401         | No authentication token found                                             | error.BadAuthorization.TokenNotFound               |
+| 401         | Invalid secret                                                            | error.BadAuthorization.InvalidSecret               |
+| 401         | Invalid token                                                             | error.BadAuthorization.InvalidToken                |
+| 401         | Invalid token - jwt audience invalid. expected: not-expected-audience     | error.BadAuthorization.error.BadAuthorization.InvalidToken.JwtAudienceInvalid.Expected:Not-expected-audience               |
+| 401         | Invalid token - jwt expired                                               | error.BadAuthorization.error.BadAuthorization.InvalidToken.JwtExpired                |
+| 401         | Invalid token - jwt issuer invalid. expected: http://wrong                | error.BadAuthorization.error.BadAuthorization.InvalidToken.JwtIssuerInvalid.Expected:Http://wrong                |
+| 401         | Invalid token - invalid signature                                         | error.BadAuthorization.InvalidToken.InvalidSignature                |
+| 401         | Bad Authorization header format. Format is "Authorization: Bearer {token}"| error.BadAuthorization.InvalidHeaderFormat |
+
 ## Install
 
 ```

--- a/index.js
+++ b/index.js
@@ -18,9 +18,6 @@ module.exports = function(opts) {
   }
 
   var middleware = function *jwt(next) {
-
-    console.log('test middleware');
-
     var token, msg, user, parts, scheme, credentials, secret;
 
     for (var i = 0; i < tokenResolvers.length; i++) {
@@ -33,18 +30,18 @@ module.exports = function(opts) {
     }
 
     if (!token && !opts.passthrough) {
-      this.throw(401, 'No authentication token found\n');
+      this.throw(401, 'error.BadAuthorization.TokenNotFound');
     }
 
     secret = (this.state && this.state.secret) ? this.state.secret : opts.secret;
     if (!secret) {
-      this.throw(500, 'Invalid secret\n');
+      this.throw(401, 'error.BadAuthorization.InvalidSecret');
     }
 
     try {
       user = yield JWT.verify(token, secret, opts);
     } catch(e) {
-      msg = 'Invalid token' + (opts.debug ? ' - ' + e.message + '\n' : '\n');
+      msg = 'error.BadAuthorization.InvalidToken' + (opts.debug ? '.' + e.message.capitalize() : '');
     }
 
     if (user || opts.passthrough) {
@@ -88,7 +85,7 @@ function resolveAuthorizationHeader(opts) {
     }
   } else {
     if (!opts.passthrough) {
-      this.throw(401, 'Bad Authorization header format. Format is "Authorization: Bearer <token>"\n');
+      this.throw(401, 'error.BadAuthorization.InvalidHeaderFormat');
     }
   }
 }
@@ -109,6 +106,21 @@ function resolveCookies(opts) {
     return this.cookies.get(opts.cookie);
   }
 }
+
+/**
+ * capitalize - Capitalize each first letter of a string and remove spaces.
+ *
+ * @return {String}   The capitalized string
+ */
+String.prototype.capitalize = function() {
+    var splitStr = this.toLowerCase().split(' ');
+   for (var i = 0; i < splitStr.length; i++) {
+       splitStr[i] = splitStr[i].charAt(0).toUpperCase() + splitStr[i].substring(1);     
+   }
+   // Directly return the joined string
+   return splitStr.join(''); 
+}
+
 
 // Export JWT methods as a convenience
 module.exports.sign   = _JWT.sign;

--- a/index.js
+++ b/index.js
@@ -18,6 +18,9 @@ module.exports = function(opts) {
   }
 
   var middleware = function *jwt(next) {
+
+    console.log('test middleware');
+
     var token, msg, user, parts, scheme, credentials, secret;
 
     for (var i = 0; i < tokenResolvers.length; i++) {

--- a/test.js
+++ b/test.js
@@ -8,7 +8,7 @@ var koajwt  = require('./index');
 
 describe('failure tests', function () {
 
-  it('should throw 401 if no authorization header', function(done) {
+  it('should throw 460 if no authorization header', function(done) {
     var app = koa();
 
     app.use(koajwt({ secret: 'shhhh' }));
@@ -26,7 +26,7 @@ describe('failure tests', function () {
       .get('/')
       .set('Authorization', 'wrong')
       .expect(401)
-      .expect('Bad Authorization header format. Format is "Authorization: Bearer <token>"\n')
+      .expect('error.BadAuthorization.InvalidHeaderFormat')
       .end(done);
   });
 
@@ -53,7 +53,7 @@ describe('failure tests', function () {
     request(app.listen())
       .get('/')
       .expect(401)
-      .expect('Invalid token\n')
+      .expect('error.BadAuthorization.InvalidToken')
       .end(done);
   });
 
@@ -65,7 +65,7 @@ describe('failure tests', function () {
       .get('/')
       .set('Authorization', 'Bearer wrongjwt')
       .expect(401)
-      .expect('Invalid token\n')
+      .expect('error.BadAuthorization.InvalidToken')
       .end(done);
   });
 
@@ -80,7 +80,7 @@ describe('failure tests', function () {
       .get('/')
       .set('Authorization', 'Bearer ' + token)
       .expect(401)
-      .expect('Invalid token - invalid signature\n')
+      .expect('error.BadAuthorization.InvalidToken.InvalidSignature')
       .end(done);
       //   assert.equal(err.message, 'invalid signature');
   });
@@ -100,7 +100,7 @@ describe('failure tests', function () {
       .get('/')
       .set('Cookie', 'jwt=bad' + token + ';')
       .expect(401)
-      .expect('Invalid token\n')
+      .expect('error.BadAuthorization.InvalidToken')
       .end(done);
 
   });
@@ -116,7 +116,7 @@ describe('failure tests', function () {
       .get('/')
       .set('Authorization', 'Bearer ' + token)
       .expect(401)
-      .expect('Invalid token - jwt audience invalid. expected: not-expected-audience\n')
+      .expect('error.BadAuthorization.InvalidToken.JwtAudienceInvalid.Expected:Not-expected-audience')
       .end(done);
   });
 
@@ -131,7 +131,7 @@ describe('failure tests', function () {
       .get('/')
       .set('Authorization', 'Bearer ' + token)
       .expect(401)
-      .expect('Invalid token - jwt expired\n')
+      .expect('error.BadAuthorization.InvalidToken.JwtExpired')
       .end(done);
   });
 
@@ -146,7 +146,7 @@ describe('failure tests', function () {
       .get('/')
       .set('Authorization', 'Bearer ' + token)
       .expect(401)
-      .expect('Invalid token - jwt issuer invalid. expected: http://wrong\n')
+      .expect('error.BadAuthorization.InvalidToken.JwtIssuerInvalid.Expected:Http://wrong')
       .end(done);
   });
 
@@ -160,8 +160,8 @@ describe('failure tests', function () {
     request(app.listen())
       .get('/')
       .set('Authorization', 'Bearer ' + token)
-      .expect(500)
-      .expect('Internal Server Error')
+      .expect(401)
+      .expect('error.BadAuthorization.InvalidSecret')
       .end(done);
   });
 
@@ -176,7 +176,7 @@ describe('failure tests', function () {
         .get('/')
         .set('Authorization', 'Bearer ' + token)
         .expect(401)
-        .expect('Invalid token - invalid signature\n')
+        .expect('error.BadAuthorization.InvalidToken.InvalidSignature')
         .end(done);
   });
 
@@ -418,7 +418,7 @@ describe('unless tests', function () {
       .get('/private')
       .set('Authorization', 'wrong')
       .expect(401)
-      .expect('Bad Authorization header format. Format is "Authorization: Bearer <token>"\n')
+      .expect('error.BadAuthorization.InvalidHeaderFormat')
       .end(done);
   });
 


### PR DESCRIPTION
Changed the status of exceptions returned by jwt to catch them more accurately.

New status code:

| Status code | koa-jwt exception                                                         | Bnbsitter exception                                |
|-------------|---------------------------------------------------------------------------|----------------------------------------------------|
| 401         | No authentication token found                                             | error.BadAuthorization.TokenNotFound               |
| 401         | Invalid secret                                                            | error.BadAuthorization.InvalidSecret               |
| 401         | Invalid token                                                             | error.BadAuthorization.InvalidToken                |
| 401         | Invalid token - jwt audience invalid. expected: not-expected-audience     | error.BadAuthorization.error.BadAuthorization.InvalidToken.JwtAudienceInvalid.Expected:Not-expected-audience               |
| 401         | Invalid token - jwt expired                                               | error.BadAuthorization.error.BadAuthorization.InvalidToken.JwtExpired                |
| 401         | Invalid token - jwt issuer invalid. expected: http://wrong                | error.BadAuthorization.error.BadAuthorization.InvalidToken.JwtIssuerInvalid.Expected:Http://wrong                |
| 401         | Invalid token - invalid signature                                         | error.BadAuthorization.InvalidToken.InvalidSignature                |
| 401         | Bad Authorization header format. Format is "Authorization: Bearer {token}"| error.BadAuthorization.InvalidHeaderFormat |
