### PR TITLE
Use jwt-then and export methods

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,6 @@
 'use strict';
 const assert    = require('assert');
-const Promise   = require('bluebird');
-const JWT       = Promise.promisifyAll(require('jsonwebtoken'));
+const JWT       = require('jwt-then');
 const unless    = require('koa-unless');
 const util      = require('util');
 
@@ -36,7 +35,7 @@ module.exports = function(opts) {
       ctx.throw(401, 'Invalid secret\n');
     }
 
-    return JWT.verifyAsync(token, secret, opts)
+    return JWT.verify(token, secret, opts)
       .then((user) => {
         ctx.state = ctx.state || {};
         ctx.state[opts.key] = user;

--- a/lib/index.js
+++ b/lib/index.js
@@ -100,3 +100,8 @@ function resolveCookies(ctx, opts) {
     return ctx.cookies.get(opts.cookie);
   }
 }
+
+// Export jwt-then methods as a convenience
+module.exports.sign   = JWT.sign;
+module.exports.verify = JWT.verify;
+module.exports._jwt = JWT._jwt;

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
   "license": "MIT",
   "main": "./lib",
   "dependencies": {
-    "bluebird": "^3.4.6",
-    "jsonwebtoken": "^7.1.9",
+    "jwt-then": "^0.6.0",
     "koa-unless": "^1.0.0"
   },
   "devDependencies": {

--- a/test/test-server.js
+++ b/test/test-server.js
@@ -1,7 +1,7 @@
 'use strict';
 const Koa = require('koa');
 const koajwt = require('../lib');
-const jwt = require('jsonwebtoken');
+const jwt = require('jwt-then')._jwt;
 
 const profile = {
   id: 123

--- a/test/test.js
+++ b/test/test.js
@@ -4,7 +4,7 @@ const TOKEN = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJmb28iOiJiYXIiLCJpYXQiOjE0
 const Koa     = require('koa');
 const request = require('supertest');
 const assert  = require('assert');
-const jwt     = require('jsonwebtoken');
+const jwt     = require('jwt-then')._jwt;
 
 const koajwt  = require('../lib');
 


### PR DESCRIPTION
After reading through #40 I gave [`jwt-then`](https://github.com/fl0w/jwt-then) another chance and it passes all tests.
Also koa-v2 doesn't export the methods from `jsonwebtoken` now it exports the methods from `jwt-then`.