### PR TITLE
Add support for several secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ alternative is to have an earlier middleware set `ctx.state.secret`,
 typically per request. If this property exists, it will be used instead
 of the one in `opts.secret`.
 
+The secret can also be an array. In that case all the secrets will be
+tried in order.
+
 
 ## Example
 

--- a/index.js
+++ b/index.js
@@ -34,14 +34,19 @@ module.exports = function(opts) {
     }
 
     secret = (this.state && this.state.secret) ? this.state.secret : opts.secret;
+
     if (!secret) {
       this.throw(500, 'Invalid secret\n');
     }
 
-    try {
-      user = yield JWT.verify(token, secret, opts);
-    } catch(e) {
-      msg = 'Invalid token' + (opts.debug ? ' - ' + e.message + '\n' : '\n');
+    secret = (Array.isArray(secret)) ? secret : [secret];
+
+    for (var i = 0; i < secret.length; i++) {
+      try {
+        user = yield JWT.verify(token, secret[i], opts);
+      } catch(e) {
+        msg = 'Invalid token' + (opts.debug ? ' - ' + e.message + '\n' : '\n');
+      }
     }
 
     if (user || opts.passthrough) {


### PR DESCRIPTION
Add support for several secrets that the JWT will be tried against. The first valid secret will be used. If passthrough is disabled and debugging enabled the error of the last verify operation will be displayed.