### PR TITLE
provide raw token to request state context to facilitate proxying

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ module.exports = function(opts) {
     if (user || opts.passthrough) {
       this.state = this.state || {};
       this.state[opts.key] = user;
+      this.state.token = token;
       yield next;
     } else {
       this.throw(401, msg);

--- a/test.js
+++ b/test.js
@@ -350,6 +350,29 @@ describe('success tests', function () {
   });
 
 
+  it('should provide the raw token to the state context', function (done) {
+    var validUserResponse = function (res) {
+      if (!(res.body.token === token)) return "Token not passed through";
+    }
+
+    var secret = 'shhhhhh';
+    var token = koajwt.sign({foo: 'bar'}, secret);
+
+    var app = koa();
+
+    app.use(koajwt({ secret: secret, key: 'jwtdata' }));
+    app.use(function* (next) {
+      this.body = { token: this.state.token };
+    });
+
+    request(app.listen())
+      .get('/')
+      .set('Authorization', 'Bearer ' + token)
+      .expect(200)
+      .expect(validUserResponse)
+      .end(done);
+  });
+
   it('should use middleware secret if both middleware and options provided', function (done) {
     var validUserResponse = function(res) {
       if (!(res.body.foo === 'bar')) return "Wrong user";


### PR DESCRIPTION
For our use cases we often need to send the raw token to some other service behind the initial web request layer. This facilitates access to the raw token from the Koa context in addition to having the decoded payload.

1 line change, has test coverage.