### PR TITLE
Populate state with undecoded token

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ module.exports = function(opts) {
     if (user || opts.passthrough) {
       this.state = this.state || {};
       this.state[opts.key] = user;
+      this.state.token = token;
       yield next;
     } else {
       this.throw(401, msg);

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ var JWT = {decode: _JWT.decode, sign: _JWT.sign, verify: thunkify(_JWT.verify)};
 module.exports = function(opts) {
   opts = opts || {};
   opts.key = opts.key || 'user';
+  opts.tokenKey = opts.tokenKey || 'token';
 
   var tokenResolvers = [resolveCookies, resolveAuthorizationHeader];
 
@@ -47,7 +48,7 @@ module.exports = function(opts) {
     if (user || opts.passthrough) {
       this.state = this.state || {};
       this.state[opts.key] = user;
-      this.state.token = token;
+      this.state[opts.tokenKey] = token;
       yield next;
     } else {
       this.throw(401, msg);

--- a/index.js
+++ b/index.js
@@ -84,10 +84,10 @@ function resolveAuthorizationHeader(opts) {
     if (/^Bearer$/i.test(scheme)) {
       return credentials;
     }
-  } else {
-    if (!opts.passthrough) {
-      this.throw(401, 'Bad Authorization header format. Format is "Authorization: Bearer <token>"\n');
-    }
+  }
+
+  if (!opts.passthrough) {
+    this.throw(401, 'Bad Authorization header format. Format is "Authorization: Bearer <token>"\n');
   }
 }
 

--- a/test.js
+++ b/test.js
@@ -30,6 +30,18 @@ describe('failure tests', function () {
       .end(done);
   });
 
+  it('should return 401 if authorization header does not start with "Bearer "', function(done) {
+    var app = koa();
+
+    app.use(koajwt({ secret: 'shhhh' }));
+    request(app.listen())
+      .get('/')
+      .set('Authorization', 'Beer sometoken')
+      .expect(401)
+      .expect('Bad Authorization header format. Format is "Authorization: Bearer <token>"\n')
+      .end(done);
+  });
+
   it('should allow provided getToken function to throw', function(done) {
     var app = koa();
 

--- a/test.js
+++ b/test.js
@@ -350,6 +350,29 @@ describe('success tests', function () {
   });
 
 
+  it('should provide the raw token to the state context', function (done) {
+    var validUserResponse = function (res) {
+      if (!(res.body.token === token)) return "Token not passed through";
+    }
+
+    var secret = 'shhhhhh';
+    var token = koajwt.sign({foo: 'bar'}, secret);
+
+    var app = koa();
+
+    app.use(koajwt({ secret: secret, key: 'jwtdata' }));
+    app.use(function* (next) {
+      this.body = { token: this.state.token };
+    });
+
+    request(app.listen())
+      .get('/')
+      .set('Authorization', 'Bearer ' + token)
+      .expect(200)
+      .expect(validUserResponse)
+      .end(done);
+  });
+
   it('should use middleware secret if both middleware and options provided', function (done) {
     var validUserResponse = function(res) {
       if (!(res.body.foo === 'bar')) return "Wrong user";

--- a/test.js
+++ b/test.js
@@ -372,9 +372,9 @@ describe('success tests', function () {
 
     var app = koa();
 
-    app.use(koajwt({ secret: secret, key: 'jwtdata' }));
+    app.use(koajwt({ secret: secret, key: 'jwtdata', tokenKey: 'testTokenKey' }));
     app.use(function* (next) {
-      this.body = { token: this.state.token };
+      this.body = { token: this.state.testTokenKey };
     });
 
     request(app.listen())


### PR DESCRIPTION
This extends the work done by @petermelias in https://github.com/koajs/jwt/pull/66.

When a token is successfully validated, the token is inserted into `this.state`. The key within `this.state` that the token is added to is set in `options.tokenKey` and defaults to `token`.  