### PR TITLE
update tokenKey for backward compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ app.use(jwt({ secret: 'shared-secret', key: 'jwtdata' }));
 ```
 This makes the decoded data available as `ctx.state.jwtdata`.
 
-If a valid token is found, the original raw token is made available as `ctx.state.token`.
-You can use a different key in `ctx.state` by setting `opts.tokenKey` to your desired key.
+If the `tokenKey` option is present, and a valid token is found, the original raw token
+is made available to subsequent middleware as `ctx.state[opts.tokenKey]`.
 
 You can specify audience and/or issuer as well:
 ```js

--- a/index.js
+++ b/index.js
@@ -47,7 +47,9 @@ module.exports = function(opts) {
     if (user || opts.passthrough) {
       this.state = this.state || {};
       this.state[opts.key] = user;
-      this.state[opts.tokenKey] = token;
+      if (opts.tokenKey) {
+        this.state[opts.tokenKey] = token;
+      }
       yield next;
     } else {
       this.throw(401, msg);


### PR DESCRIPTION
 Before I update npm, I've changed the tokenKey functionality slightly. 

In case anyone is using the library already and have anything on `ctx.state.token`, to avoid accidentally clobbering ctx.state.token on an update of koa-jwt, `opts.tokenKey` does not have a default.

 In order to have the token available on `ctx.state.token`, you need to specifically set `opts.tokenKey` to `token`.