### PR TITLE
Remove Bluebird and refactor using async/await

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,7 @@ module.exports = (opts = {}) => {
             ctx.throw(401, 'No authentication token found\n');
         }
 
-        const secret = ctx.state && ctx.state.secret || opts.secret;
+        const { state: { secret = opts.secret } = {} } = ctx;
         if (!secret) {
             ctx.throw(401, 'Invalid secret\n');
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
+'use strict';
 const unless = require('koa-unless');
 const verify = require('./verify');
 const resolveAuthHeader = require('./resolvers/auth-header');

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,7 +32,7 @@ module.exports = (opts = {}) => {
             if (isRevoked) {
                 const tokenRevoked = await isRevoked(ctx, decodedToken, token);
                 if (tokenRevoked) {
-                    ctx.throw(401, 'Revoked token');
+                    throw new Error('Revoked token');
                 }
             }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,104 +1,57 @@
-'use strict';
-const Promise   = require('bluebird');
-const JWT       = Promise.promisifyAll(require('jsonwebtoken'));
-const unless    = require('koa-unless');
+const unless = require('koa-unless');
+const verify = require('./verify');
+const resolveAuthHeader = require('./resolvers/auth-header');
+const resolveCookies = require('./resolvers/cookie');
 
-module.exports = opts => {
-  opts = opts || {};
-  opts.key = opts.key || 'user';
+module.exports = (opts = {}) => {
 
-  const tokenResolvers = [resolveCookies, resolveAuthorizationHeader];
+    const { debug, getToken, isRevoked, key='user', passthrough, tokenKey } = opts;
+    const tokenResolvers = [resolveCookies, resolveAuthHeader];
 
-  if (opts.getToken && typeof opts.getToken === 'function') {
-    tokenResolvers.unshift(opts.getToken);
-  }
-
-  const identity = user => user;
-  const isRevoked = opts.isRevoked
-      ? (ctx, token) => user => opts.isRevoked(ctx, user, token).then(revocationHandler(user))
-      : () => identity;
-
-  const middleware = function jwt(ctx, next) {
-    let token;
-    tokenResolvers.find((resolver) => token = resolver(ctx, opts));
-
-    if (!token && !opts.passthrough) {
-      ctx.throw(401, 'No authentication token found\n');
+    if (getToken && typeof getToken === 'function') {
+        tokenResolvers.unshift(getToken);
     }
 
-    const secret = ctx.state && ctx.state.secret || opts.secret;
-    if (!secret) {
-      ctx.throw(401, 'Invalid secret\n');
-    }
+    const middleware = async function jwt(ctx, next) {
+        let token;
+        tokenResolvers.find(resolver => token = resolver(ctx, opts));
 
-    return JWT.verifyAsync(token, secret, opts)
-      .then(isRevoked(ctx, token))
-      .then(user => {
-        ctx.state = ctx.state || {};
-        ctx.state[opts.key] = user;
-        if (opts.tokenKey) {
-          ctx.state[opts.tokenKey] = token;
+        if (!token && !passthrough) {
+            ctx.throw(401, 'No authentication token found\n');
         }
-      })
-      .catch(e => {
-        if (!opts.passthrough) {
-          const msg = 'Invalid token' + (opts.debug ? ' - ' + e.message : '') + '\n';
-          ctx.throw(401, msg);
+
+        const secret = ctx.state && ctx.state.secret || opts.secret;
+        if (!secret) {
+            ctx.throw(401, 'Invalid secret\n');
         }
-      })
-      .then(next);
-  };
 
-  middleware.unless = unless;
+        try {
+            const decodedToken = await verify(token, secret, opts);
 
-  return middleware;
+            if (isRevoked) {
+                const tokenRevoked = await isRevoked(ctx, decodedToken, token);
+                if (tokenRevoked) {
+                    ctx.throw(401, 'Revoked token');
+                }
+            }
+
+            ctx.state = ctx.state || {};
+            ctx.state[key] = decodedToken;
+            if (tokenKey) {
+                ctx.state[tokenKey] = token;
+            }
+
+        } catch (e) {
+            if (!passthrough) {
+                const debugString = debug ? ` - ${e.message}` : '';
+                const msg = `Invalid token${debugString}\n`;
+                ctx.throw(401, msg);
+            }
+        }
+
+        return next();
+    };
+
+    middleware.unless = unless;
+    return middleware;
 };
-
-
-/**
- * resolveAuthorizationHeader - Attempts to parse the token from the Authorization header
- *
- * This function checks the Authorization header for a `Bearer <token>` pattern and return the token section
- *
- * @param {Object}        ctx  The ctx object passed to the middleware
- * @param {Object}        opts The middleware's options
- * @return {String|null}  The resolved token or null if not found
- */
-function resolveAuthorizationHeader(ctx, opts) {
-  if (!ctx.header || !ctx.header.authorization) {
-    return;
-  }
-
-  const parts = ctx.header.authorization.split(' ');
-
-  if (parts.length === 2) {
-    const scheme = parts[0];
-    const credentials = parts[1];
-
-    if (/^Bearer$/i.test(scheme)) {
-      return credentials;
-    }
-  }
-  if (!opts.passthrough) {
-    ctx.throw(401, 'Bad Authorization header format. Format is "Authorization: Bearer <token>"\n');
-  }
-}
-
-/**
- * resolveCookies - Attempts to retrieve the token from a cookie
- *
- * This function uses the opts.cookie option to retrieve the token
- *
- * @param {Object}        ctx  The ctx object passed to the middleware
- * @param {Object}        opts This middleware's options
- * @return {String|null|undefined}  The resolved token or null if not found or undefined if opts.cookie is not set
- */
-function resolveCookies(ctx, opts) {
-  return opts.cookie && ctx.cookies.get(opts.cookie);
-}
-
-function revocationHandler(user) {
-  return revoked => revoked
-    ? Promise.reject(new Error('Revoked token'))
-    : Promise.resolve(user);
-}

--- a/lib/resolvers/auth-header.js
+++ b/lib/resolvers/auth-header.js
@@ -1,0 +1,28 @@
+/**
+ * resolveAuthorizationHeader - Attempts to parse the token from the Authorization header
+ *
+ * This function checks the Authorization header for a `Bearer <token>` pattern and return the token section
+ *
+ * @param {Object}        ctx  The ctx object passed to the middleware
+ * @param {Object}        opts The middleware's options
+ * @return {String|null}  The resolved token or null if not found
+ */
+module.exports = function resolveAuthorizationHeader(ctx, opts) {
+    if (!ctx.header || !ctx.header.authorization) {
+        return;
+    }
+
+    const parts = ctx.header.authorization.split(' ');
+
+    if (parts.length === 2) {
+        const scheme = parts[0];
+        const credentials = parts[1];
+
+        if (/^Bearer$/i.test(scheme)) {
+            return credentials;
+        }
+    }
+    if (!opts.passthrough) {
+        ctx.throw(401, 'Bad Authorization header format. Format is "Authorization: Bearer <token>"\n');
+    }
+};

--- a/lib/resolvers/cookie.js
+++ b/lib/resolvers/cookie.js
@@ -1,0 +1,12 @@
+/**
+ * resolveCookies - Attempts to retrieve the token from a cookie
+ *
+ * This function uses the opts.cookie option to retrieve the token
+ *
+ * @param {Object}        ctx  The ctx object passed to the middleware
+ * @param {Object}        opts This middleware's options
+ * @return {String|null|undefined}  The resolved token or null if not found or undefined if opts.cookie is not set
+ */
+module.exports = function resolveCookies(ctx, opts) {
+    return opts.cookie && ctx.cookies.get(opts.cookie);
+}

--- a/lib/verify.js
+++ b/lib/verify.js
@@ -1,0 +1,9 @@
+const jwt = require('jsonwebtoken');
+
+module.exports = (...args) => {
+    return new Promise((resolve, reject) => {
+        jwt.verify(...args, (error, decoded) => {
+            error ? reject(error) : resolve(decoded);
+        });
+    });
+};

--- a/package.json
+++ b/package.json
@@ -39,14 +39,14 @@
     "report-dir": "./coverage"
   },
   "dependencies": {
-    "jsonwebtoken": "^7.1.9",
+    "jsonwebtoken": "^7.3.0",
     "koa-unless": "^1.0.0"
   },
   "devDependencies": {
-    "koa": "^2.0.0",
-    "mocha": "~3.1.0",
+    "koa": "^2.0.1",
+    "mocha": "~3.2.0",
     "nyc": "^10.1.2",
-    "supertest": "~2.0.0"
+    "supertest": "~3.0.0"
   },
   "engines": {
     "node": ">= 7.6.0"

--- a/package.json
+++ b/package.json
@@ -31,22 +31,28 @@
   },
   "license": "MIT",
   "main": "./lib",
+  "nyc": {
+    "reporter": [
+      "lcov",
+      "text-summary"
+    ],
+    "report-dir": "./coverage"
+  },
   "dependencies": {
-    "bluebird": "^3.4.6",
     "jsonwebtoken": "^7.1.9",
     "koa-unless": "^1.0.0"
   },
   "devDependencies": {
-    "istanbul": "~0.4.5",
     "koa": "^2.0.0",
     "mocha": "~3.1.0",
+    "nyc": "^10.1.2",
     "supertest": "~2.0.0"
   },
   "engines": {
     "node": ">= 7.6.0"
   },
   "scripts": {
-    "test": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter spec --bail test/test.js",
+    "test": "nyc npm run test-only",
     "test-only": "mocha --reporter spec --bail test/test.js"
   }
 }


### PR DESCRIPTION
* Bluebird has been removed in favour of a native promise wrapper around jsonwebtoken
* The complex and hard-to-follow promise chain has been reimplemented using `async / await`
* The resolver functions have been moved to their own files
* istanbul replaced with nyc for coverage