### PR TITLE
The use of async/await bumps node requirement to 7.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "supertest": "~0.15.0"
   },
   "engines": {
-    "node": ">= 0.12.0"
+    "node": ">= 7.7.4"
   },
   "scripts": {
     "test": "mocha --reporter spec --bail ./test.js"


### PR DESCRIPTION
What was the reasoning behind this and what are codebases that do not use babel or edge node supposed to do?