### PR TITLE
Consistent error messages, 100% coverage, misc tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/*
 npm-debug.log
 coverage
 .nyc_output
+.idea

--- a/lib/get-secret.js
+++ b/lib/get-secret.js
@@ -1,7 +1,12 @@
 const { decode } = require('jsonwebtoken');
 
 module.exports = async (provider, token) => {
-  const { header } = decode(token, { complete: true });
 
-  return provider(header);
-}
+  const decoded = decode(token, { complete: true });
+
+  if (!decoded || !decoded.header) {
+    throw new Error('Invalid token');
+  }
+
+  return provider(decoded.header);
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,17 +19,18 @@ module.exports = (opts = {}) => {
         tokenResolvers.find(resolver => token = resolver(ctx, opts));
 
         if (!token && !passthrough) {
-            ctx.throw(401, 'No authentication token found\n');
+            ctx.throw(401, debug ? 'Token not found' : 'Authentication Error');
         }
 
-        let { state: { secret = opts.secret } = {} } = ctx;
-        if (!secret) {
-            ctx.throw(401, 'Invalid secret\n');
-        }
+        let { state: { secret = opts.secret } } = ctx;
 
         try {
             if(typeof secret === 'function') {
               secret = await getSecret(secret, token);
+            }
+
+            if (!secret) {
+                ctx.throw(401, 'Secret not provided');
             }
 
             const decodedToken = await verify(token, secret, opts);
@@ -37,11 +38,10 @@ module.exports = (opts = {}) => {
             if (isRevoked) {
                 const tokenRevoked = await isRevoked(ctx, decodedToken, token);
                 if (tokenRevoked) {
-                    throw new Error('Revoked token');
+                    throw new Error('Token revoked');
                 }
             }
 
-            ctx.state = ctx.state || {};
             ctx.state[key] = decodedToken;
             if (tokenKey) {
                 ctx.state[tokenKey] = token;
@@ -49,8 +49,7 @@ module.exports = (opts = {}) => {
 
         } catch (e) {
             if (!passthrough) {
-                const debugString = debug ? ` - ${e.message}` : '';
-                const msg = `Invalid token${debugString}\n`;
+                const msg = debug ? e.message : 'Authentication Error';
                 ctx.throw(401, msg);
             }
         }

--- a/lib/resolvers/auth-header.js
+++ b/lib/resolvers/auth-header.js
@@ -23,6 +23,6 @@ module.exports = function resolveAuthorizationHeader(ctx, opts) {
         }
     }
     if (!opts.passthrough) {
-        ctx.throw(401, 'Bad Authorization header format. Format is "Authorization: Bearer <token>"\n');
+        ctx.throw(401, 'Bad Authorization header format. Format is "Authorization: Bearer <token>"');
     }
 };

--- a/lib/resolvers/cookie.js
+++ b/lib/resolvers/cookie.js
@@ -9,4 +9,4 @@
  */
 module.exports = function resolveCookies(ctx, opts) {
     return opts.cookie && ctx.cookies.get(opts.cookie);
-}
+};

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
   },
   "scripts": {
     "test": "nyc npm run test-only",
-    "test-only": "mocha --reporter spec --bail test/test.js"
+    "test-only": "mocha --reporter spec test/test.js"
   }
 }


### PR DESCRIPTION
* add `/.idea` to .gitignore for webstorm devs
* remove mocha `--bail` flag on test run to show all errors
* catch invalid token errors before calling secret provider function
* Remove the trailing newlines from thrown errors
* For security, when `debug`=`false`, all thrown errors have the same message
* Koa defaults `ctx.state` to `{}` so no need to do this ourselves
* add test for passthrough with bad token to give us 100% coverage
* fixed some minor linting issues and phrasing