### PR TITLE
Added audience, issuer, and algorithms type definitions

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -17,6 +17,9 @@ declare namespace jwt {
         passthrough?: boolean;
         cookie?: string;
         debug?: boolean;
+        audience?: string;
+        issuer?: string;
+        algorithms?: string[];
     }
 
     export interface Middleware extends Koa.Middleware {


### PR DESCRIPTION
I added type definitions for commonly used options `audience`, `issuer`, and `algorithms`.
Related to #109 