### PR TITLE
Update types for secret being a function

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -11,7 +11,7 @@ declare function jwt(options: jwt.Options): jwt.Middleware;
 
 declare namespace jwt {
     export interface Options {
-        secret: string | Buffer;
+        secret: string | Buffer | Function;
         key?: string;
         tokenKey?: string;
         getToken?(opts: jwt.Options): string;


### PR DESCRIPTION
With typescript the scenario described [here in the readme](https://github.com/koajs/jwt#token-verification-exceptions): 
```js
const { koaJwtSecret } = require('jwks-rsa');

app.use(jwt({ secret: koaJwtSecret({
                        jwksUri: 'https://sandrino.auth0.com/.well-known/jwks.json',
                        cache: true,
                        cacheMaxEntries: 5,
                        cacheMaxAge: ms('10h') }),
              audience: 'http://myapi/protected',
              issuer:   'http://issuer' }));
```
Will result in 
```
error TS2345: Argument of type '{ secret: (name: string, scheme: string, options?: any) => void; }' is not assignable to parameter of type 'Options'.
  Type '(name: string, scheme: string, options?: any) => void' is not assignable to type 'string | Buffer'.
```

This is a quick fix for that. As stated in the read me the signature or `secret`, if a function, is expected to be `(header) => Promise(secret)`, but since the [types of `jwks-rsa`](https://github.com/auth0/node-jwks-rsa/blob/master/index.d.ts#L38) also seems a bit off (returning `(name: string, scheme: string, options?: any) => void`) this will work for that. It should be better than error:ing at least.