### PR TITLE
Accept a secret provider as a secret parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,11 +44,13 @@
     "koa-unless": "1.0.0"
   },
   "devDependencies": {
+    "@types/koa": "^2.0.44",
+    "chai": "latest",
     "koa": "^2.0.1",
     "mocha": "3.2.0",
-    "chai": "latest",
     "nyc": "10.1.2",
-    "supertest": "3.0.0"
+    "supertest": "3.0.0",
+    "ts-node": "^5.0.1"
   },
   "engines": {
     "node": ">= 7.6.0"

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Bruno Krebs <https://github.com/brunokrebs/>
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 
-import Koa = require('koa');
+import * as Koa from 'koa';
 
 export = jwt;
 
@@ -11,7 +11,7 @@ declare function jwt(options: jwt.Options): jwt.Middleware;
 
 declare namespace jwt {
     export interface Options {
-        secret: string | Buffer;
+        secret: (header?: object, payload?: string) => Promise<string | Buffer> | string | Buffer;
         key?: string;
         tokenKey?: string;
         getToken?(opts: jwt.Options): string;


### PR DESCRIPTION
This works for me. I tried to extrapolate what the secret provider parameter types are since my provider doesn't care for them. Basically the secret field must accept a function you pass as the provider to get-secret which returns a promise to something that could otherwise be accepted as a secret - string or a buffer. Let me know if I'm wrong on the payload type.