### PR TITLE
Bumped jsonwebtoken from v8.0.0 to v8.3.0 (Fixes #130) 

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "report-dir": "./coverage"
   },
   "dependencies": {
-    "jsonwebtoken": "8.0.0",
+    "jsonwebtoken": "8.3.0",
     "koa-unless": "1.0.7"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "jsonwebtoken": "8.0.0",
-    "koa-unless": "1.0.0"
+    "koa-unless": "1.0.7"
   },
   "devDependencies": {
     "koa": "^2.0.1",


### PR DESCRIPTION
### Main changes ###

- [X] Bumped core dependencies to their current latest version
  + [`jsonwebtoken`: v8.0.0 --> v8.3.0](https://github.com/auth0/node-jsonwebtoken/blob/master/CHANGELOG.md)
  + `koa-unless`: v1.0.0 --> v1.0.7 (no changelog)

This fixes the warning highlighted in #130:
```
warning koa-jwt > jsonwebtoken > lodash.isarray@4.0.0: This package is deprecated. Use Array.isArray
```