### PR TITLE
fix typescript definitions for koa

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,8 +250,8 @@ app.use(jwt({ secret: publicKey }));
 If the `secret` option is a function, this function is called for each JWT received in
 order to determine which secret is used to verify the JWT.
 
-The signature of this function should be `(header) => [Promise(secret)]`, where
-`header` is token header. For instance to support JWKS token header should contain
+The signature of this function should be `(header, payload) => [Promise(secret)]`, where
+`header` is the token header and `payload` is the token payload. For instance to support JWKS token header should contain
 `alg` and `kid`: algorithm and key id fields respectively.
 
 This option can be used to support JWKS (JSON Web Key Set) providers by using

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -11,7 +11,7 @@ declare function jwt(options: jwt.Options): jwt.Middleware;
 
 declare namespace jwt {
     export interface Options {
-        secret: string | Buffer;
+        secret: string | Buffer | SecretLoader;
         key?: string;
         tokenKey?: string;
         getToken?(opts: jwt.Options): string;
@@ -23,6 +23,8 @@ declare namespace jwt {
         issuer?: string;
         algorithms?: string[];
     }
+
+    export type SecretLoader = (header: any, payload: any) => Promise<string | Buffer>;
 
     export interface Middleware extends Koa.Middleware {
         unless(params?: any): any;


### PR DESCRIPTION
Also update readme with correct signature.

After I made this I found #122 and #123. The types here are better:

- #122 has deliberately vague type to work round rubbish types in another repo
- `object` used for the header param in #123 is the empty interface, which isn't what we want because it might have members
- the payload is actually only a string if it can't be decoded (see source for jsonwebtoken)