### PR TITLE
Lets downstream middlewares handle JWT exceptions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ even if no valid Authorization header was found:
 app.use(jwt({ secret: 'shared-secret', passthrough: true }));
 ```
 
-This lets downstream middleware make decisions based on whether `ctx.state.user` is set. You can still handle errors using  `ctx.state.jwtOriginalError`
+This lets downstream middleware make decisions based on whether `ctx.state.user` is set. You can still handle errors using  `ctx.state.jwtOriginalError`.
 
 If you prefer to use another ctx key for the decoded data, just pass in `key`, like so:
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ even if no valid Authorization header was found:
 app.use(jwt({ secret: 'shared-secret', passthrough: true }));
 ```
 
-This lets downstream middleware make decisions based on whether `ctx.state.user` is set.
+This lets downstream middleware make decisions based on whether `ctx.state.user` is set. You can still handle errors using  `ctx.state.jwtOriginalError`
 
 If you prefer to use another ctx key for the decoded data, just pass in `key`, like so:
 
@@ -227,7 +227,7 @@ If the JWT has an expiration (`exp`), it will be checked.
 
 All error codes for token verification can be found at: [https://github.com/auth0/node-jsonwebtoken#errors--codes](https://github.com/auth0/node-jsonwebtoken#errors--codes).
 
-Notifying a client of error codes (e.g token expiration) can be achieved by sending the `err.originalError.message` error code to the client.
+Notifying a client of error codes (e.g token expiration) can be achieved by sending the `err.originalError.message` error code to the client. If passthrough is enabled use `ctx.state.jwtOriginalError`.
 
 ```js
 // Custom 401 handling (first middleware)

--- a/lib/index.js
+++ b/lib/index.js
@@ -66,6 +66,9 @@ module.exports = (opts = {}) => {
             if (!passthrough) {
                 const msg = debug ? e.message : 'Authentication Error';
                 ctx.throw(401, msg, { originalError: e });
+            }else{ 
+                //lets downstream middlewares handle JWT exceptions
+                ctx.state.jwtOriginalError = e;
             }
         }
 


### PR DESCRIPTION
When `passthrough` is true there is no way to catch errors.  I added original jwt errors in `ctx.state.jwtOriginalError`. This lets downstream middlewares handle JWT exceptions. I also updated readme file.