### PR TITLE
koa-unless path supports strings, RegExps and arrays of these (typing issue).

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -27,6 +27,6 @@ declare namespace jwt {
     export type SecretLoader = (header: any, payload: any) => Promise<string | string[] | Buffer | Buffer[]>;
 
     export interface Middleware extends Koa.Middleware {
-        unless(params?: { path: RegExp[] }): Koa.Middleware;
+        unless(params?: { path: string | string[] | RegExp | RegExp[] }): Koa.Middleware;
     }
 }


### PR DESCRIPTION
https://github.com/Foxandxss/koa-unless#current-options
> path it could be an string, a regexp or an array of any of those. If the request path match, the middleware will not run.

💖