### PR TITLE
updated typescript definitions, fix types/index.ts, make the type hint support more argument for koa-unless, such as `custom, ext, method

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -27,6 +27,6 @@ declare namespace jwt {
     export type SecretLoader = (header: any, payload: any) => Promise<string | string[] | Buffer | Buffer[]>;
 
     export interface Middleware extends Koa.Middleware {
-        unless(params?: { path: string | string[] | RegExp | RegExp[] }): Koa.Middleware;
+        unless(params?: {custom?: (ctx: Koa.Context) => boolean, path?: string | string[] | RegExp | RegExp[], ext?: string | string[],  method?: string | string[]}): Koa.Middleware;
     }
 }


### PR DESCRIPTION
fix types/index.ts, make the type hint support more argument for koa-unless, such as `custom, ext, method ...`

also the koa-unless path argument is optional,  not necessary.