### PR TITLE
Fix typing of `path` property

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -27,6 +27,6 @@ declare namespace jwt {
     export type SecretLoader = (header: any, payload: any) => Promise<string | string[] | Buffer | Buffer[]>;
 
     export interface Middleware extends Koa.Middleware {
-        unless(params?: { path: string | string[] | RegExp | RegExp[] }): Koa.Middleware;
+        unless(params?: { path: string | RegExp | (string | RegExp)[] }): Koa.Middleware;
     }
 }


### PR DESCRIPTION
`string[] | RegExp[]` only allows either array of `string` or array of `RegExp`.
`(string | RegExp)[]` allows array of `string` or `RegExp`.