### PR TITLE
Support whitespace pre bearer post colon

### DIFF
--- a/lib/resolvers/auth-header.js
+++ b/lib/resolvers/auth-header.js
@@ -12,7 +12,7 @@ module.exports = function resolveAuthorizationHeader(ctx, opts) {
         return;
     }
 
-    const parts = ctx.header.authorization.split(' ');
+    const parts = ctx.header.authorization.trim().split(' ');
 
     if (parts.length === 2) {
         const scheme = parts[0];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-jwt",
-  "version": "3.6.0",
+  "version": "4.0.0",
   "description": "Koa middleware for validating JSON Web Tokens",
   "main": "./lib",
   "types": "types/index.d.ts",

--- a/test/test.js
+++ b/test/test.js
@@ -433,6 +433,27 @@ describe('success tests', () => {
       .end(done);
   });
 
+  it('should work if authorization header contains leading and/or trailing whitespace', done => {
+    const validUserResponse = res => res.body.foo !== 'bar' && 'Wrong user';
+
+    const secret = 'shhhhhh';
+    const token = jwt.sign({foo: 'bar'}, secret);
+
+    const app = new Koa();
+
+    app.use(koajwt({ secret: secret }));
+    app.use(ctx => {
+      ctx.body = ctx.state.user;
+    });
+
+    request(app.listen())
+      .get('/')
+      .set('Authorization', `     Bearer ${token}     `)
+      .expect(200)
+      .expect(validUserResponse)
+      .end(done);
+  });
+
   it('should work if authorization header is valid jwt according to one of the secrets', done => {
     const validUserResponse = res => res.body.foo !== 'bar' && 'Wrong user';
 


### PR DESCRIPTION
HTTP spec permits optional leading / trailing whitespace in HTTP header values.

This adds support for Authorization headers that contain valid optional whitespace.

Issue: https://github.com/koajs/jwt/issues/156