### PR TITLE
Fix typing of `getToken`

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -14,7 +14,7 @@ declare namespace jwt {
         secret: string | string[] | Buffer | Buffer[] | SecretLoader;
         key?: string;
         tokenKey?: string;
-        getToken?(ctx: Koa.Context, opts: jwt.Options): string;
+        getToken?(ctx: Koa.Context, opts: jwt.Options): string | null;
         isRevoked?(ctx: Koa.Context, decodedToken: object, token: string): Promise<boolean>;
         passthrough?: boolean;
         cookie?: string;


### PR DESCRIPTION
According to the [readme](https://github.com/koajs/jwt#retrieving-the-token), `null` should be returned from `getToken` if the token is not found.